### PR TITLE
Refactor of dynamic classification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,11 @@ A working default configuration is provided with the service.
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
-| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classified as bulk | uint | 10 |
+| threaded_client_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
 | threaded_client_class | The class applied to threaded bulk clients | string | le |
 | threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
 | threaded_service_class | The class applied to threaded high-throughput services | string | af13 |
 | dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
-| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | uint | 5 * threaded_service_bytes |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 <br />

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ The service supports three modes for classifying and DSCP marking connections.
 ### User rules
 The service will first attempt to classify new connections using rules specified by the user in the config file.<br />
 These follow a similar syntax to the OpenWrt firewall config and can match upon source/destination ports and IPs, firewall zones etc.<br />
+Below is an example:
 
+```
+config rule
+	option name 'DNS'
+	list proto 'tcp'
+	list proto 'udp'
+	list dest_port '53'
+	list dest_port '853'
+	list dest_port '5353'
+	option class 'cs5'
+```
 ### Client DSCP hinting
 The service can be configured to apply the DSCP mark supplied by a non WAN originating client.<br />
 This function ignores CS6 and CS7 classes to avoid abuse from inappropriately configed LAN clients such as IoT devices.
@@ -19,7 +30,7 @@ This function ignores CS6 and CS7 classes to avoid abuse from inappropriately co
 Connections that do not match a pre-specified rule will be dynamically classified by the service via three mechanisms:
 
 * Multi-threaded client port detection for detecting P2P traffic
-  * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
+  * These connections are classified as Bulk (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
 * Increased priority for low throughput small packet UDP streams such as VoIP/game traffic.
@@ -61,8 +72,18 @@ rm -f /usr/lib/sqm/layer_cake_ct.qos.help
 wget https://raw.githubusercontent.com/jeverley/dscpclassify/main/usr/lib/sqm/layer_cake_ct.qos -P /usr/lib/sqm
 wget https://raw.githubusercontent.com/jeverley/dscpclassify/main/usr/lib/sqm/layer_cake_ct.qos.help -P /usr/lib/sqm
 ```
+
+The 'layer_cake_ct.qos' qdisc setup script must then be selected for your wan device in SQM setup:
+
+![image](https://user-images.githubusercontent.com/46714706/190709086-c2e820ed-11ed-4be4-8e57-fba4ab6db190.png)
+
+
+<br />
+
 ## Service configuration
 The user rules in '/etc/config/dscpclassify' use the same syntax as OpenWrt's firewall config, the 'class' option is used to specified the desired DSCP.
+
+The OpenWrt firewall syntax is outlined here https://openwrt.org/docs/guide-user/firewall/firewall_configuration
 
 A working default configuration is provided with the service.
 
@@ -71,35 +92,15 @@ A working default configuration is provided with the service.
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
-| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classified as bulk | uint | 10 |
+| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classed as bulk | int | 10 |
 | threaded_client_class | The class applied to threaded bulk clients | string | le |
-| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
+| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | int | 1000000 |
 | threaded_service_class | The class applied to threaded high-throughput services | string | af13 |
 | dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
-| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | uint | 5 * threaded_service_bytes |
+| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | int | 5 * threaded_service_bytes |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
-**Below is an example user rule:**
-
-```
-config rule
-	option name 'DNS'
-	list proto 'tcp'
-	list proto 'udp'
-	list dest_port '53'
-	list dest_port '853'
-	list dest_port '5353'
-	option class 'cs5'
-```
-The OpenWrt firewall syntax is outlined here https://openwrt.org/docs/guide-user/firewall/firewall_configuration
-
-## SQM configuration
-
-The **'layer_cake_ct.qos'** queue setup script must be selected for your wan device in SQM setup:
-
-![image](https://user-images.githubusercontent.com/46714706/190709086-c2e820ed-11ed-4be4-8e57-fba4ab6db190.png)
-
-
+<br />
 <br />
 
 **Below is a tested working SQM config for use with the service:**

--- a/README.md
+++ b/README.md
@@ -10,18 +10,7 @@ The service supports three modes for classifying and DSCP marking connections.
 ### User rules
 The service will first attempt to classify new connections using rules specified by the user in the config file.<br />
 These follow a similar syntax to the OpenWrt firewall config and can match upon source/destination ports and IPs, firewall zones etc.<br />
-Below is an example:
 
-```
-config rule
-	option name 'DNS'
-	list proto 'tcp'
-	list proto 'udp'
-	list dest_port '53'
-	list dest_port '853'
-	list dest_port '5353'
-	option class 'cs5'
-```
 ### Client DSCP hinting
 The service can be configured to apply the DSCP mark supplied by a non WAN originating client.<br />
 This function ignores CS6 and CS7 classes to avoid abuse from inappropriately configed LAN clients such as IoT devices.
@@ -72,18 +61,8 @@ rm -f /usr/lib/sqm/layer_cake_ct.qos.help
 wget https://raw.githubusercontent.com/jeverley/dscpclassify/main/usr/lib/sqm/layer_cake_ct.qos -P /usr/lib/sqm
 wget https://raw.githubusercontent.com/jeverley/dscpclassify/main/usr/lib/sqm/layer_cake_ct.qos.help -P /usr/lib/sqm
 ```
-
-The 'layer_cake_ct.qos' qdisc setup script must then be selected for your wan device in SQM setup:
-
-![image](https://user-images.githubusercontent.com/46714706/190709086-c2e820ed-11ed-4be4-8e57-fba4ab6db190.png)
-
-
-<br />
-
 ## Service configuration
 The user rules in '/etc/config/dscpclassify' use the same syntax as OpenWrt's firewall config, the 'class' option is used to specified the desired DSCP.
-
-The OpenWrt firewall syntax is outlined here https://openwrt.org/docs/guide-user/firewall/firewall_configuration
 
 A working default configuration is provided with the service.
 
@@ -99,7 +78,27 @@ A working default configuration is provided with the service.
 | dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
-<br />
+**Below is an example user rule:**
+
+```
+config rule
+	option name 'DNS'
+	list proto 'tcp'
+	list proto 'udp'
+	list dest_port '53'
+	list dest_port '853'
+	list dest_port '5353'
+	option class 'cs5'
+```
+The OpenWrt firewall syntax is outlined here https://openwrt.org/docs/guide-user/firewall/firewall_configuration
+
+## SQM configuration
+
+The **'layer_cake_ct.qos'** queue setup script must be selected for your wan device in SQM setup:
+
+![image](https://user-images.githubusercontent.com/46714706/190709086-c2e820ed-11ed-4be4-8e57-fba4ab6db190.png)
+
+
 <br />
 
 **Below is a tested working SQM config for use with the service:**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This function ignores CS6 and CS7 classes to avoid abuse from inappropriately co
 Connections that do not match a pre-specified rule will be dynamically classified by the service via three mechanisms:
 
 * Multi-threaded client port detection for detecting P2P traffic
-  * These connections are classified as Bulk (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
+  * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
 * Increased priority for low throughput small packet UDP streams such as VoIP/game traffic.
@@ -92,12 +92,12 @@ A working default configuration is provided with the service.
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
-| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classed as bulk | int | 10 |
+| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classified as bulk | uint | 10 |
 | threaded_client_class | The class applied to threaded bulk clients | string | le |
-| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | int | 1000000 |
+| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
 | threaded_service_class | The class applied to threaded high-throughput services | string | af13 |
 | dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
-| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | int | 5 * threaded_service_bytes |
+| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | uint | 5 * threaded_service_bytes |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 <br />

--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Connections that do not match a pre-specified rule will be dynamically classifie
   * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
-* Increased priority for small packet streams such as VoIP/game traffic.
-  * These connections are classified as Real-Time (CS4) by default and are processed by layer-cake in the Voice tin.
-* Increased priority for larger packet streams such as video conference traffic.
-  * These connections are classified as Conference Video (AF41) by default and are processed by layer-cake in the Video tin.
+* Increased priority for real-time streams such as VoIP/game traffic.
+  * Small packet connections are classified as Real-Time (CS4) by default and are processed by layer-cake in the Voice tin.
+  * Larger packet connections are classified as Conference Video (AF41) by default and are processed by layer-cake in the Video tin.
 
 ### External classification
 The service will respect DSCP classification stored by an external service in a connection's conntrack bits, this could include services such as netifyd.
@@ -72,15 +71,16 @@ A working default configuration is provided with the service.
 
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
-| client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
 | class_bulk | The class applied to threaded bulk clients | string | le |
 | class_high_throughput | The class applied to threaded high-throughput services | string | af13 |
 | class_realtime | The class applied to dynamic real-time connections | string | cs4 |
 | class_video_conference | The class applied to video conference connections | string | af41 |
+| client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
 | threaded_client_min_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
 | threaded_service_min_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
-| realtime_max_pps | The maximum packets per second for dynamic realtime connections | uint | 100 |
-| realtime_max_avgpkt | The maximum average packet size in bytes for dynamic realtime connections | uint | 450 |
+| realtime_max_avgpkt | The maximum average packet size in bytes (directional) for dynamic realtime connections | uint | 450 |
+| realtime_max_pps | The maximum packets per second (directional) for dynamic realtime connections | uint | 100 |
+| realtime_min_pps | The minimum packets per second (directional) for dynamic realtime connections | uint | 20 |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 **Below is an example user rule:**

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Connections that do not match a pre-specified rule will be dynamically classifie
   * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
-* Increased priority for low throughput small packet UDP streams such as VoIP/game traffic.
+* Increased priority for small packet streams such as VoIP/game traffic.
   * These connections are classified as Real-Time (CS4) by default and are processed by layer-cake in the Voice tin.
-  
+* Increased priority for larger packet streams such as video conference traffic.
+  * These connections are classified as Conference Video (AF41) by default and are processed by layer-cake in the Video tin.
+
 ### External classification
 The service will respect DSCP classification stored by an external service in a connection's conntrack bits, this could include services such as netifyd.
 
@@ -71,11 +73,14 @@ A working default configuration is provided with the service.
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
-| threaded_client_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
-| threaded_client_class | The class applied to threaded bulk clients | string | le |
-| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
-| threaded_service_class | The class applied to threaded high-throughput services | string | af13 |
-| dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
+| class_bulk | The class applied to threaded bulk clients | string | le |
+| class_high_throughput | The class applied to threaded high-throughput services | string | af13 |
+| class_realtime | The class applied to dynamic real-time connections | string | cs4 |
+| class_video_conference | The class applied to video conference connections | string | af41 |
+| threaded_client_min_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
+| threaded_service_min_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
+| realtime_max_pps | The maximum packets per second for dynamic realtime connections | uint | 100 |
+| realtime_max_avgpkt | The maximum average packet size in bytes for dynamic realtime connections | uint | 450 |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 **Below is an example user rule:**

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Connections that do not match a pre-specified rule will be dynamically classifie
   * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
-* Increased priority for real-time streams such as VoIP/game traffic.
-  * Small packet connections are classified as Real-Time (CS4) by default and are processed by layer-cake in the Voice tin.
-  * Larger packet connections are classified as Conference Video (AF41) by default and are processed by layer-cake in the Video tin.
 
 ### External classification
 The service will respect DSCP classification stored by an external service in a connection's conntrack bits, this could include services such as netifyd.
@@ -73,14 +70,9 @@ A working default configuration is provided with the service.
 |---|---|---|---|
 | class_bulk | The class applied to threaded bulk clients | string | le |
 | class_high_throughput | The class applied to threaded high-throughput services | string | af13 |
-| class_realtime | The class applied to dynamic real-time connections | string | cs4 |
-| class_video_conference | The class applied to video conference connections | string | af41 |
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
 | threaded_client_min_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
 | threaded_service_min_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
-| realtime_max_avgpkt | The maximum average packet size in bytes (directional) for dynamic realtime connections | uint | 450 |
-| realtime_max_pps | The maximum packets per second (directional) for dynamic realtime connections | uint | 100 |
-| realtime_min_pps | The minimum packets per second (directional) for dynamic realtime connections | uint | 20 |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 **Below is an example user rule:**

--- a/etc/config/dscpclassify
+++ b/etc/config/dscpclassify
@@ -1,14 +1,9 @@
 config global 'global'
 	option class_bulk 'le'
 	option class_high_throughput 'af13'
-	option class_video_conference 'af41'
-	option class_realtime 'cs4'
 	option client_hints '1'
 	option threaded_client_min_bytes '10000'
 	option threaded_service_min_bytes '1000000'
-	option realtime_max_avgpkt '450'
-	option realtime_max_pps '100'
-	option realtime_min_pps '20'
 	option wmm '1'
 
 config set

--- a/etc/config/dscpclassify
+++ b/etc/config/dscpclassify
@@ -1,6 +1,6 @@
 config global 'global'
 	option client_hints '1'
-	option threaded_client_kbps '10'
+	option threaded_client_bytes '10000'
 	option threaded_client_class 'le'
 	option threaded_service_bytes '1000000'
 	option threaded_service_class 'af13'

--- a/etc/config/dscpclassify
+++ b/etc/config/dscpclassify
@@ -1,13 +1,14 @@
 config global 'global'
 	option class_bulk 'le'
-	option class_video_conference 'af41'
 	option class_high_throughput 'af13'
+	option class_video_conference 'af41'
 	option class_realtime 'cs4'
 	option client_hints '1'
 	option threaded_client_min_bytes '10000'
 	option threaded_service_min_bytes '1000000'
-	option realtime_max_pps '100'
 	option realtime_max_avgpkt '450'
+	option realtime_max_pps '100'
+	option realtime_min_pps '20'
 	option wmm '1'
 
 config set

--- a/etc/config/dscpclassify
+++ b/etc/config/dscpclassify
@@ -1,10 +1,13 @@
 config global 'global'
+	option class_bulk 'le'
+	option class_video_conference 'af41'
+	option class_high_throughput 'af13'
+	option class_realtime 'cs4'
 	option client_hints '1'
-	option threaded_client_bytes '10000'
-	option threaded_client_class 'le'
-	option threaded_service_bytes '1000000'
-	option threaded_service_class 'af13'
-	option dynamic_realtime_class 'cs4'
+	option threaded_client_min_bytes '10000'
+	option threaded_service_min_bytes '1000000'
+	option realtime_max_pps '100'
+	option realtime_max_avgpkt '450'
 	option wmm '1'
 
 config set

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -154,7 +154,7 @@ table inet dscpclassify {
 
     chain dynamic_classify {
         # Ignore non TCP/UDP connections
-        meta l4proto != { tcp, udp } return
+        meta l4proto != { tcp, udp } goto ct_set_cs0
 
         ## Detect connection threading by counting connections opened within a time period
         ct packets 1 goto detect_threading

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -6,9 +6,10 @@ include "/tmp/etc/dscpclassify-pre.include"
 ## Masks for extracting/storing data in the conntrack mark
 define ct_dscp = 0x0000003f
 define ct_dyn = 0x00000080
-define ct_dyn_dscp = 0x000000ff
-define ct_unclassified = 0x00000040
+define ct_dyn_static_dscp = 0x000000ff
+define ct_static = 0x00000040
 define ct_unused = 0xffffff00
+define ct_unused_dscp = 0xffffff3f
 define ct_unused_dyn = 0xffffff80
 
 ## DSCP classification values
@@ -131,7 +132,7 @@ table inet dscpclassify {
     chain input {
         type filter hook input priority 2; policy accept
         meta iifname "lo" return
-        ct mark and $ct_dyn_dscp == 0 ct direction original jump static_classify
+        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
     }
 
@@ -139,7 +140,7 @@ table inet dscpclassify {
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
         meta oifname "lo" return
-        ct mark and $ct_dyn_dscp == 0 ct direction original jump static_classify
+        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
 
         ## DSCP marking rules are added here by the init script
@@ -148,53 +149,81 @@ table inet dscpclassify {
     chain static_classify {
         ## User defined rules in '/etc/config/dscpclassify' are inserted here by the init script
 
-        ## Unclassified packets get dynamic conntrack mark
+        ## Non TCP/UDP unclassified connections are Best Effort (CS0)
+        meta l4proto != { tcp, udp } goto ct_set_cs0
+
+        ## Set the dynamic conntrack bit on unclassified connections
         ct mark set ct mark and $ct_unused or $ct_dyn
     }
 
     chain dynamic_classify {
-        # Ignore non TCP/UDP connections
-        meta l4proto != { tcp, udp } goto ct_set_cs0
+        ## Unreplied connections are ignored by dynamic classification logic
+        ct status and seen-reply != seen-reply return
 
-        ## Detect connection threading by counting connections opened within a time period
-        ct packets 1 goto detect_threading
-
-        ## Non-established connections are ignored by dynamic classification logic
-        ct state new return
+        ## Handle connection replies
+        ct direction reply goto dynamic_classify_reply
 
         ## Assess threaded client connections (i.e. P2P) for classification
-        meta l4proto . ip saddr . th sport @threaded_clients goto threaded_client
-        meta l4proto . ip6 saddr . th sport @threaded_clients6 goto threaded_client
-        meta l4proto . ip daddr . th dport @threaded_clients goto threaded_client_response
-        meta l4proto . ip6 daddr . th dport @threaded_clients6 goto threaded_client_response
+        ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
+        ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client
 
         ## Assess threaded service connections for classification
-        meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport @threaded_services goto threaded_service
-        meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport @threaded_services6 goto threaded_service
-        meta l4proto . ip daddr . ip saddr and 255.255.255.0 . th sport @threaded_services goto threaded_service_response
-        meta l4proto . ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport @threaded_services6 goto threaded_service_response
+        ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
+        ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
 
         ## Assess UDP connections for real-time classification
-        meta l4proto udp th dport != { 80, 443 } th sport != { 80, 443 } jump dynamic_realtime
+        udp dport != { 80, 443 } jump dynamic_realtime
 
-        ## The unclassified connection rule is added here by the init script
+        ## A connection's dynamic classification is fixed after it expires from the countdown set
+        ct id != @dynamic_countdown ct mark set ct mark and $ct_unused_dscp or $ct_static
     }
 
-    chain detect_threading {
+    chain dynamic_classify_reply {
+        ## Established connection
+        ct reply packets 1 jump established_connection
+
+        ## Assess threaded client connections (i.e. P2P) for classification
+        ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
+        ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply
+
+        ## Assess threaded service connections for classification
+        ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
+        ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
+
+        ## Assess UDP connections for real-time classification
+        udp sport != { 80, 443 } jump dynamic_realtime
+
+        ## A connection's dynamic classification is fixed after it expires from the countdown set
+        ct id != @dynamic_countdown ct mark set ct mark and $ct_unused_dscp or $ct_static
+    }
+
+    chain established_connection {
+        ## Remember new connections for 60s
+        add @dynamic_countdown { ct id timeout 1m }
+
         ## Detect multiple connections being opened from a single source port (i.e. P2P)
-        meter tcdetect { meta l4proto . ip saddr . th sport timeout 5s limit rate over 10/minute } add @threaded_clients { meta l4proto . ip saddr . th sport timeout 5s }
-        meter tcdetect6 { meta l4proto . ip6 saddr . th sport timeout 5s limit rate over 10/minute } add @threaded_clients6 { meta l4proto . ip6 saddr . th sport timeout 5s }
+        meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 5s }
+        meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5s }
 
         ## Detect multiple connections being opened to a service from a single source address
-        meter tsdetect { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 5s limit rate over 2/minute } add @threaded_services { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 20s }
-        meter tsdetect6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 5s limit rate over 2/minute } add @threaded_services6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 20s }
+        meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }
+        meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
+    }
+
+    chain dynamic_realtime {
+        ## High-throughput connections exceeding 200pps are classified as Best Effort (CS0)
+        ct direction original meter ht_orig_detect { ct id limit rate over 200/second burst 100 packets } update @high_throughput { ct id timeout 1m } ct mark set ct mark and $ct_unused_dyn or $cs0 return
+        ct direction reply meter ht_reply_detect { ct id limit rate over 200/second burst 100 packets } update @high_throughput { ct id timeout 1m } ct mark set ct mark and $ct_unused_dyn or $cs0 return
+        ct id @high_throughput return
+
+        ## Dynamic real-time rules are added here by the init script
     }
 
     chain threaded_client {
         ## Threaded client rules are added here by the init script
     }
 
-    chain threaded_client_response {
+    chain threaded_client_reply {
         ## Threaded client rules are added here by the init script
     }
 
@@ -202,50 +231,38 @@ table inet dscpclassify {
         ## Threaded service rules are added here by the init script
     }
 
-    chain threaded_service_response {
+    chain threaded_service_reply {
         ## Threaded service rules are added here by the init script
-    }
-
-    chain dynamic_realtime {
-        ## Classify high-throughput connections exceeding 200pps as Best Effort (CS0)
-        meter htdetect { ip saddr . th sport . ip daddr . th dport limit rate over 200/second burst 100 packets } update @high_throughput { ip saddr . th sport . ip daddr . th dport timeout 5s } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-        meter htdetect6 { ip6 saddr . th sport . ip6 daddr . th dport limit rate over 200/second burst 100 packets } update @high_throughput6 { ip6 saddr . th sport . ip6 daddr . th dport timeout 5s } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-
-        ## Return high-throughput connection responses
-        ip daddr . th dport . ip saddr . th sport @high_throughput return
-        ip6 daddr . th dport . ip6 saddr . th sport @high_throughput6 return
-
-        ## Dynamic real-time rules are added here by the init script
     }
 
     ## Sets for stateful tracking
     set threaded_clients {
-        type inet_proto . ipv4_addr . inet_service
+        type ipv4_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_clients6 {
-        type inet_proto . ipv6_addr . inet_service
+        type ipv6_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_services {
-        type inet_proto . ipv4_addr . ipv4_addr . inet_service
+        type ipv4_addr . ipv4_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_services6 {
-        type inet_proto . ipv6_addr . ipv6_addr . inet_service
+        type ipv6_addr . ipv6_addr . inet_service . inet_proto
         flags timeout
     }
 
     set high_throughput {
-        type ipv4_addr . inet_service . ipv4_addr . inet_service
+        typeof ct id
         flags timeout
     }
 
-    set high_throughput6 {
-        type ipv6_addr . inet_service . ipv6_addr . inet_service
+    set dynamic_countdown {
+        typeof ct id
         flags timeout
     }
 
@@ -367,7 +384,7 @@ table inet dscpclassify {
 
     ## Set conntrack DSCP mark without modifying unused bits
     chain ct_set_cs0 {
-        ct mark set ct mark and $ct_unused or $cs0 or $ct_unclassified
+        ct mark set ct mark and $ct_unused or $cs0 or $ct_static
     }
 
     chain ct_set_le {

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -171,11 +171,7 @@ table inet dscpclassify {
         ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
         ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
 
-        ## Assess UDP connections for real-time classification
-        udp dport != { 80, 443 } jump dynamic_realtime
-
-        ## A connection's dynamic classification is fixed after it expires from the countdown set
-        ct id != @dynamic_countdown ct mark set ct mark and $ct_unused_dscp or $ct_static
+        ## Dynamic rules are added here by the init script
     }
 
     chain dynamic_classify_reply {
@@ -190,33 +186,17 @@ table inet dscpclassify {
         ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
         ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
 
-        ## Assess UDP connections for real-time classification
-        udp sport != { 80, 443 } jump dynamic_realtime
-
-        ## A connection's dynamic classification is fixed after it expires from the countdown set
-        ct id != @dynamic_countdown ct mark set ct mark and $ct_unused_dscp or $ct_static
+        ## Dynamic rules are added here by the init script
     }
 
     chain established_connection {
-        ## Remember new connections for 60s
-        add @dynamic_countdown { ct id timeout 1m }
-
         ## Detect multiple connections being opened from a single source port (i.e. P2P)
-        meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 5s }
-        meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5s }
+        meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+        meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }
 
         ## Detect multiple connections being opened to a service from a single source address
         meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }
         meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
-    }
-
-    chain dynamic_realtime {
-        ## High-throughput connections exceeding 200pps are classified as Best Effort (CS0)
-        ct direction original meter ht_orig_detect { ct id limit rate over 200/second burst 100 packets } update @high_throughput { ct id timeout 1m } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-        ct direction reply meter ht_reply_detect { ct id limit rate over 200/second burst 100 packets } update @high_throughput { ct id timeout 1m } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-        ct id @high_throughput return
-
-        ## Dynamic real-time rules are added here by the init script
     }
 
     chain threaded_client {
@@ -257,11 +237,6 @@ table inet dscpclassify {
     }
 
     set high_throughput {
-        typeof ct id
-        flags timeout
-    }
-
-    set dynamic_countdown {
         typeof ct id
         flags timeout
     }

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -154,7 +154,7 @@ table inet dscpclassify {
 
     chain dynamic_classify {
         # Ignore non TCP/UDP connections
-        meta l4proto != { tcp, udp } goto ct_set_cs0
+        meta l4proto != { tcp, udp } return
 
         ## Detect connection threading by counting connections opened within a time period
         ct packets 1 goto detect_threading

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -444,49 +444,6 @@ create_threaded_service_rule() {
 	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_$class_high_throughput"
 }
 
-create_dynamic_rule() {
-	local class_video_conference class_realtime realtime_max_avgpkt realtime_max_pps realtime_min_pps
-
-	config_get class_video_conference global class_video_conference af41
-	class_realtime="$(check_class "$class_video_conference" var)" || {
-		log error "Global option class_video_conference contains an invalid DSCP class"
-		return 1
-	}
-	config_get class_realtime global class_realtime cs4
-	class_realtime="$(check_class "$class_realtime" var)" || {
-		log error "Global option class_realtime contains an invalid DSCP class"
-		return 1
-	}
-	config_get_uint realtime_max_avgpkt global realtime_max_avgpkt 450 || {
-		log error "Global option realtime_max_avgpkt contains an invalid number"
-		return 1
-	}
-	config_get_uint realtime_max_pps global realtime_max_pps 100 || {
-		log error "Global option realtime_max_pps contains an invalid number"
-		return 1
-	}
-	config_get_uint realtime_min_pps global realtime_min_pps 20 || {
-		log error "Global option realtime_min_pps contains an invalid number"
-		return 1
-	}
-
-	post_include "add rule inet dscpclassify dynamic_classify th dport { 80, 443 } return"
-	post_include "add rule inet dscpclassify dynamic_classify meter ht_orig_pps { ct id limit rate over $realtime_max_pps/second burst $realtime_max_pps packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
-	post_include "add rule inet dscpclassify dynamic_classify ct id @high_throughput return"
-	post_include "add rule inet dscpclassify dynamic_classify meter rt_orig_pps { ct id limit rate $realtime_min_pps/second burst $realtime_min_pps packets } return"
-	post_include "add rule inet dscpclassify dynamic_classify ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
-	post_include "add rule inet dscpclassify dynamic_classify ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
-	post_include "add rule inet dscpclassify dynamic_classify ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"
-
-	post_include "add rule inet dscpclassify dynamic_classify_reply th sport { 80, 443 } return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply meter ht_reply_pps { ct id limit rate over $realtime_max_pps/second burst $realtime_max_pps packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply ct id @high_throughput return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply meter rt_reply_pps { ct id limit rate $realtime_min_pps/second burst $realtime_min_pps packets } return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"
-}
-
 create_dscp_mark_rule() {
 	local wmm
 
@@ -517,7 +474,6 @@ create_post_include() {
 
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
-	create_dynamic_rule || return 1
 
 	create_dscp_mark_rule || return 1
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -445,16 +445,8 @@ create_threaded_service_rule() {
 }
 
 create_dynamic_rule() {
-	local class_video_conference class_realtime realtime_max_avgpkt realtime_max_pps
+	local class_video_conference class_realtime realtime_max_avgpkt realtime_max_pps realtime_min_pps
 
-	config_get_uint realtime_max_pps global realtime_max_pps 100 || {
-		log error "Global option realtime_max_pps contains an invalid number"
-		return 1
-	}
-	config_get_uint realtime_max_avgpkt global realtime_max_avgpkt 450 || {
-		log error "Global option realtime_max_avgpkt contains an invalid number"
-		return 1
-	}
 	config_get class_video_conference global class_video_conference af41
 	class_realtime="$(check_class "$class_video_conference" var)" || {
 		log error "Global option class_video_conference contains an invalid DSCP class"
@@ -465,19 +457,31 @@ create_dynamic_rule() {
 		log error "Global option class_realtime contains an invalid DSCP class"
 		return 1
 	}
+	config_get_uint realtime_max_avgpkt global realtime_max_avgpkt 450 || {
+		log error "Global option realtime_max_avgpkt contains an invalid number"
+		return 1
+	}
+	config_get_uint realtime_max_pps global realtime_max_pps 100 || {
+		log error "Global option realtime_max_pps contains an invalid number"
+		return 1
+	}
+	config_get_uint realtime_min_pps global realtime_min_pps 20 || {
+		log error "Global option realtime_min_pps contains an invalid number"
+		return 1
+	}
 
 	post_include "add rule inet dscpclassify dynamic_classify th dport { 80, 443 } return"
-	post_include "add rule inet dscpclassify dynamic_classify meter ht_orig_pps { ct id limit rate over $realtime_max_pps/second burst 100 packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
+	post_include "add rule inet dscpclassify dynamic_classify meter ht_orig_pps { ct id limit rate over $realtime_max_pps/second burst $realtime_max_pps packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
 	post_include "add rule inet dscpclassify dynamic_classify ct id @high_throughput return"
-	post_include "add rule inet dscpclassify dynamic_classify ct packets < 8 return"
+	post_include "add rule inet dscpclassify dynamic_classify meter rt_orig_pps { ct id limit rate $realtime_min_pps/second burst $realtime_min_pps packets } return"
 	post_include "add rule inet dscpclassify dynamic_classify ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
 	post_include "add rule inet dscpclassify dynamic_classify ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
 	post_include "add rule inet dscpclassify dynamic_classify ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"
 
 	post_include "add rule inet dscpclassify dynamic_classify_reply th sport { 80, 443 } return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply meter ht_reply_pps { ct id limit rate over $realtime_max_pps/second burst 100 packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply meter ht_reply_pps { ct id limit rate over $realtime_max_pps/second burst $realtime_max_pps packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ct id @high_throughput return"
-	post_include "add rule inet dscpclassify dynamic_classify_reply ct packets < 8 return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply meter rt_reply_pps { ct id limit rate $realtime_min_pps/second burst $realtime_min_pps packets } return"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -55,7 +55,7 @@ check_class() {
 }
 
 check_duration() {
-	echo "$1" | grep -q -E -e "^([1-9][0-9]*[smhd]){1,4}$"
+	echo "$1" | grep -q -E -e "^[[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd]$"
 }
 
 check_family() {
@@ -67,7 +67,7 @@ check_family() {
 
 check_port() {
 	for i in $1; do
-		echo "$i" | grep -q -E -e "^[1-9][0-9]*(-[1-9][0-9]*)?$" || return 1
+		echo "$i" | grep -q -E -e "^[[:digit:]]+-[[:digit:]]+$" -e "^[[:digit:]]+$" || return 1
 	done
 }
 
@@ -82,19 +82,12 @@ check_port_proto() {
 
 sort_ip() {
 	for i in $1; do
-		echo "$i" | grep -q -E -e "^(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9])[.]){3}(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9]))(\/([0-9]|[12][0-9]|3[0-2]))?$" && {
-			ipv4="$ipv4 $i"
-			continue
-		}
-		echo "$i" | grep -q -E -e "^(([a-fA-F0-9]{1,4}|):){1,7}([a-fA-F0-9]{1,4}|:)$" && {
-			ipv6="$ipv6 $i"
-			continue
-		}
-		echo "$i" | grep -q -E -e "^@\w+$" && {
-			ipset="$ipset $i"
-			continue
-		}
-		return 1
+		case $i in
+		[0-9]*.[0-9]*.[0-9]*.*[0-9]) ipv4="$ipv4 $i" ;;
+		*:*:*) ipv6="$ipv6 $i" ;;
+		@*[a-zA-Z0-9]) ipset="$ipset $i" ;;
+		*) return 1 ;;
+		esac
 	done
 }
 
@@ -304,7 +297,7 @@ create_user_set() {
 	config_get timeout "$1" timeout
 	config_get type "$1" type
 
-	if [ -z "$family$type" ] || [ -n "$family" ] && [ -n "$type" ]; then
+	if [ -z "$famiy$type" ] || [ -n "$family" ] && [ -n "$type" ]; then
 		log warning "Sets must contain either a family or type option"
 		return 1
 	fi
@@ -334,7 +327,7 @@ create_user_set() {
 
 	[ "$constant" = 1 ] && flags="$flags constant"
 	[ "$interval" = 1 ] && flags="$flags interval"
-	[ -n "$flags" ] && flags="$(mklist "$flags")"
+	[ -n "$flags" ] && flags=$(mklist $flags)
 
 	post_include "add set inet dscpclassify $name { type $type; ${timeout:+timeout $timeout;} ${flags:+flags $flags;} }"
 	[ -n "$element" ] && post_include "add element inet dscpclassify $name { $(mklist "$element") }"
@@ -403,7 +396,7 @@ create_threaded_client_rule() {
 		return 1
 	}
 	config_get threaded_client_class globals threaded_client_class le
-	threaded_client_class="$(check_class "$threaded_client_class")" || {
+	threaded_client_class="$(check_class $threaded_client_class)" || {
 		log error "Global option threaded_client_class contains an invalid DSCP class"
 		return 1
 	}
@@ -424,7 +417,7 @@ create_threaded_service_rule() {
 		return 1
 	}
 	config_get threaded_service_class globals threaded_service_class af13
-	threaded_service_class="$(check_class "$threaded_service_class")" || {
+	threaded_service_class="$(check_class $threaded_service_class)" || {
 		log error "Global option threaded_service_class contains an invalid DSCP class"
 		return 1
 	}
@@ -462,7 +455,7 @@ create_unclassified_rule() {
 		log error "Global option threaded_service_bytes contains an invalid number"
 		return 1
 	}
-	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * threaded_service_bytes)) || {
+	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * $threaded_service_bytes)) || {
 		log error "Global option unclassified_bytes contains an invalid number"
 		return 1
 	}
@@ -509,7 +502,7 @@ setup() {
 	lan="$(fw4 -q zone lan)" || exit 0
 	wan="$(fw4 -q zone wan)" || exit 0
 	config_load dscpclassify || return 1
-
+	
 	create_pre_include || return 1
 	create_post_include || return 1
 	nft -f /etc/dscpclassify.d/main.nft || return 1

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -304,7 +304,7 @@ create_user_set() {
 	config_get timeout "$1" timeout
 	config_get type "$1" type
 
-	if [ -z "$famiy$type" ] || [ -n "$family" ] && [ -n "$type" ]; then
+	if [ -z "$family$type" ] || [ -n "$family" ] && [ -n "$type" ]; then
 		log warning "Sets must contain either a family or type option"
 		return 1
 	fi

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -396,10 +396,10 @@ create_client_hints_rule() {
 }
 
 create_threaded_client_rule() {
-	local threaded_client_class threaded_client_kbps
+	local threaded_client_class threaded_client_bytes
 
-	config_get_uint threaded_client_kbps globals threaded_client_kbps 10 || {
-		log error "Global option threaded_client_kbps contains an invalid number"
+	config_get_uint threaded_client_bytes globals threaded_client_bytes 10000 || {
+		log error "Global option threaded_client_bytes contains an invalid number"
 		return 1
 	}
 	config_get threaded_client_class globals threaded_client_class le
@@ -407,13 +407,12 @@ create_threaded_client_rule() {
 		log error "Global option threaded_client_class contains an invalid DSCP class"
 		return 1
 	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
 
-	post_include "add rule inet dscpclassify threaded_client meter tcbulk { meta l4proto . ip saddr . th sport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients { meta l4proto . ip saddr . th sport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client meter tcbulk6 { meta l4proto . ip6 saddr . th sport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients6 { meta l4proto . ip6 saddr . th sport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
 
-	post_include "add rule inet dscpclassify threaded_client_response meter tcrbulk { meta l4proto . ip daddr . th dport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients { meta l4proto . ip daddr . th dport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client_response meter tcrbulk6 { meta l4proto . ip6 daddr . th dport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients6 { meta l4proto . ip6 daddr . th dport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
 }
 
 create_threaded_service_rule() {
@@ -428,17 +427,16 @@ create_threaded_service_rule() {
 		log error "Global option threaded_service_class contains an invalid DSCP class"
 		return 1
 	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
 
 	post_include "add rule inet dscpclassify threaded_service ct bytes < $threaded_service_bytes return"
-	post_include "add rule inet dscpclassify threaded_service ct mark set ct mark and \$ct_unused_dyn or \$$threaded_service_class"
-	post_include "add rule inet dscpclassify threaded_service update @threaded_services { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 60s }"
-	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 60s }"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service delete @dynamic_countdown { ct id } goto ct_set_$threaded_service_class"
 
-	post_include "add rule inet dscpclassify threaded_service_response ct bytes < $threaded_service_bytes return"
-	post_include "add rule inet dscpclassify threaded_service_response ct mark set ct mark and \$ct_unused_dyn or \$$threaded_service_class"
-	post_include "add rule inet dscpclassify threaded_service_response update @threaded_services { meta l4proto . ip daddr . ip saddr and 255.255.255.0 . th sport timeout 60s }"
-	post_include "add rule inet dscpclassify threaded_service_response update @threaded_services6 { meta l4proto . ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport timeout 60s }"
+	post_include "add rule inet dscpclassify threaded_service_reply ct bytes < $threaded_service_bytes return"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply delete @dynamic_countdown { ct id } goto ct_set_$threaded_service_class"
 }
 
 create_dynamic_realtime_rule() {
@@ -453,21 +451,6 @@ create_dynamic_realtime_rule() {
 
 	post_include "add rule inet dscpclassify dynamic_realtime ct avgpkt 0-450 ct mark set ct mark and \$ct_unused_dyn or \$$dynamic_realtime_class return"
 	post_include "add rule inet dscpclassify dynamic_realtime ct mark set ct mark and \$ct_unused_dyn or \$cs0"
-}
-
-create_unclassified_rule() {
-	local threaded_service_bytes unclassified_bytes
-
-	config_get_uint threaded_service_bytes globals threaded_service_bytes 1000000 || {
-		log error "Global option threaded_service_bytes contains an invalid number"
-		return 1
-	}
-	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * threaded_service_bytes)) || {
-		log error "Global option unclassified_bytes contains an invalid number"
-		return 1
-	}
-
-	post_include "add rule inet dscpclassify dynamic_classify ct mark and \$ct_dscp == 0 ct bytes > $unclassified_bytes goto ct_set_cs0"
 }
 
 create_dscp_mark_rule() {
@@ -498,7 +481,6 @@ create_post_include() {
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
 	create_dynamic_realtime_rule || return 1
-	create_unclassified_rule || return 1
 
 	create_dscp_mark_rule || return 1
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -55,7 +55,7 @@ check_class() {
 }
 
 check_duration() {
-	echo "$1" | grep -q -E -e "^[[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd]$" -e "^[[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd][[:digit:]]+[smhd]$"
+	echo "$1" | grep -q -E -e "^([1-9][0-9]*[smhd]){1,4}$"
 }
 
 check_family() {
@@ -67,7 +67,7 @@ check_family() {
 
 check_port() {
 	for i in $1; do
-		echo "$i" | grep -q -E -e "^[[:digit:]]+-[[:digit:]]+$" -e "^[[:digit:]]+$" || return 1
+		echo "$i" | grep -q -E -e "^[1-9][0-9]*(-[1-9][0-9]*)?$" || return 1
 	done
 }
 
@@ -82,12 +82,19 @@ check_port_proto() {
 
 sort_ip() {
 	for i in $1; do
-		case $i in
-		[0-9]*.[0-9]*.[0-9]*.*[0-9]) ipv4="$ipv4 $i" ;;
-		*:*:*) ipv6="$ipv6 $i" ;;
-		@*[a-zA-Z0-9]) ipset="$ipset $i" ;;
-		*) return 1 ;;
-		esac
+		echo "$i" | grep -q -E -e "^(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9])[.]){3}(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9]))(\/([0-9]|[12][0-9]|3[0-2]))?$" && {
+			ipv4="$ipv4 $i"
+			continue
+		}
+		echo "$i" | grep -q -E -e "^(([a-fA-F0-9]{1,4}|):){1,7}([a-fA-F0-9]{1,4}|:)$" && {
+			ipv6="$ipv6 $i"
+			continue
+		}
+		echo "$i" | grep -q -E -e "^@\w+$" && {
+			ipset="$ipset $i"
+			continue
+		}
+		return 1
 	done
 }
 
@@ -327,7 +334,7 @@ create_user_set() {
 
 	[ "$constant" = 1 ] && flags="$flags constant"
 	[ "$interval" = 1 ] && flags="$flags interval"
-	[ -n "$flags" ] && flags=$(mklist $flags)
+	[ -n "$flags" ] && flags="$(mklist "$flags")"
 
 	post_include "add set inet dscpclassify $name { type $type; ${timeout:+timeout $timeout;} ${flags:+flags $flags;} }"
 	[ -n "$element" ] && post_include "add element inet dscpclassify $name { $(mklist "$element") }"
@@ -396,7 +403,7 @@ create_threaded_client_rule() {
 		return 1
 	}
 	config_get threaded_client_class globals threaded_client_class le
-	threaded_client_class="$(check_class $threaded_client_class)" || {
+	threaded_client_class="$(check_class "$threaded_client_class")" || {
 		log error "Global option threaded_client_class contains an invalid DSCP class"
 		return 1
 	}
@@ -417,7 +424,7 @@ create_threaded_service_rule() {
 		return 1
 	}
 	config_get threaded_service_class globals threaded_service_class af13
-	threaded_service_class="$(check_class $threaded_service_class)" || {
+	threaded_service_class="$(check_class "$threaded_service_class")" || {
 		log error "Global option threaded_service_class contains an invalid DSCP class"
 		return 1
 	}
@@ -455,7 +462,7 @@ create_unclassified_rule() {
 		log error "Global option threaded_service_bytes contains an invalid number"
 		return 1
 	}
-	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * $threaded_service_bytes)) || {
+	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * threaded_service_bytes)) || {
 		log error "Global option unclassified_bytes contains an invalid number"
 		return 1
 	}
@@ -502,7 +509,7 @@ setup() {
 	lan="$(fw4 -q zone lan)" || exit 0
 	wan="$(fw4 -q zone wan)" || exit 0
 	config_load dscpclassify || return 1
-	
+
 	create_pre_include || return 1
 	create_post_include || return 1
 	nft -f /etc/dscpclassify.d/main.nft || return 1

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -45,6 +45,11 @@ check_class() {
 	class="$(echo "$1" | tr 'A-Z' 'a-z')"
 	[ "$class" = "be" ] && class="cs0"
 
+	if [ "$2" = "var" ] && [ "$class" = "le" ]; then
+		echo "lephb"
+		return 0
+	fi
+
 	case "$class" in
 	cs0 | le | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7)
 		echo "$class"
@@ -321,7 +326,7 @@ create_user_set() {
 		return 1
 	}
 	case $name in
-	threaded_clients | threaded_clients6 | threaded_services | threaded_services6 | high_throughput | high_throughput6)
+	high_throughput | threaded_clients | threaded_clients6 | threaded_services | threaded_services6)
 		log warning "Config sets cannot overwrite built-in dscpclassify sets"
 		return 1
 		;;
@@ -388,75 +393,100 @@ create_user_rule() {
 create_client_hints_rule() {
 	local client_hints
 
-	config_get_bool client_hints globals client_hints 1
+	config_get_bool client_hints global client_hints 1
 	[ "$client_hints" = 1 ] || return 0
 
-	post_include "insert rule inet dscpclassify static_classify iifname != \$wan ip6 dscp != { cs0, cs6, cs7 } ip6 dscp vmap @dscp_ct"
-	post_include "insert rule inet dscpclassify static_classify iifname != \$wan ip dscp != { cs0, cs6, cs7 } ip dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != \$wan ip6 dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify static_classify ip dscp != { cs0, cs6, cs7 } iifname != \$wan ip dscp vmap @dscp_ct"
 }
 
 create_threaded_client_rule() {
-	local threaded_client_class threaded_client_bytes
+	local class_bulk threaded_client_min_bytes
 
-	config_get_uint threaded_client_bytes globals threaded_client_bytes 10000 || {
-		log error "Global option threaded_client_bytes contains an invalid number"
+	config_get_uint threaded_client_min_bytes global threaded_client_min_bytes 10000 || {
+		log error "Global option threaded_client_min_bytes contains an invalid number"
 		return 1
 	}
-	config_get threaded_client_class globals threaded_client_class le
-	threaded_client_class="$(check_class "$threaded_client_class")" || {
-		log error "Global option threaded_client_class contains an invalid DSCP class"
+	config_get class_bulk global class_bulk le
+	class_bulk="$(check_class "$class_bulk")" || {
+		log error "Global option class_bulk contains an invalid DSCP class"
 		return 1
 	}
 
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_bytes bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } delete @dynamic_countdown { ct id } goto ct_set_$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 }
 
 create_threaded_service_rule() {
-	local threaded_service_bytes threaded_service_class
+	local class_high_throughput threaded_service_min_bytes
 
-	config_get_uint threaded_service_bytes globals threaded_service_bytes 1000000 || {
-		log error "Global option threaded_service_bytes contains an invalid number"
+	config_get_uint threaded_service_min_bytes global threaded_service_min_bytes 1000000 || {
+		log error "Global option threaded_service_min_bytes contains an invalid number"
 		return 1
 	}
-	config_get threaded_service_class globals threaded_service_class af13
-	threaded_service_class="$(check_class "$threaded_service_class")" || {
-		log error "Global option threaded_service_class contains an invalid DSCP class"
+	config_get class_high_throughput global class_high_throughput af13
+	class_high_throughput="$(check_class "$class_high_throughput")" || {
+		log error "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
 	}
 
-	post_include "add rule inet dscpclassify threaded_service ct bytes < $threaded_service_bytes return"
+	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service delete @dynamic_countdown { ct id } goto ct_set_$threaded_service_class"
+	post_include "add rule inet dscpclassify threaded_service goto ct_set_$class_high_throughput"
 
-	post_include "add rule inet dscpclassify threaded_service_reply ct bytes < $threaded_service_bytes return"
+	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service_reply delete @dynamic_countdown { ct id } goto ct_set_$threaded_service_class"
+	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_$class_high_throughput"
 }
 
-create_dynamic_realtime_rule() {
-	local dynamic_realtime_class
+create_dynamic_rule() {
+	local class_video_conference class_realtime realtime_max_avgpkt realtime_max_pps
 
-	config_get dynamic_realtime_class globals dynamic_realtime_class cs4
-	dynamic_realtime_class="$(check_class "$dynamic_realtime_class")" || {
-		log error "Global option dynamic_realtime_class contains an invalid DSCP class"
+	config_get_uint realtime_max_pps global realtime_max_pps 100 || {
+		log error "Global option realtime_max_pps contains an invalid number"
 		return 1
 	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
+	config_get_uint realtime_max_avgpkt global realtime_max_avgpkt 450 || {
+		log error "Global option realtime_max_avgpkt contains an invalid number"
+		return 1
+	}
+	config_get class_video_conference global class_video_conference af41
+	class_realtime="$(check_class "$class_video_conference" var)" || {
+		log error "Global option class_video_conference contains an invalid DSCP class"
+		return 1
+	}
+	config_get class_realtime global class_realtime cs4
+	class_realtime="$(check_class "$class_realtime" var)" || {
+		log error "Global option class_realtime contains an invalid DSCP class"
+		return 1
+	}
 
-	post_include "add rule inet dscpclassify dynamic_realtime ct avgpkt 0-450 ct mark set ct mark and \$ct_unused_dyn or \$$dynamic_realtime_class return"
-	post_include "add rule inet dscpclassify dynamic_realtime ct mark set ct mark and \$ct_unused_dyn or \$cs0"
+	post_include "add rule inet dscpclassify dynamic_classify th dport { 80, 443 } return"
+	post_include "add rule inet dscpclassify dynamic_classify meter ht_orig_pps { ct id limit rate over $realtime_max_pps/second burst 100 packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
+	post_include "add rule inet dscpclassify dynamic_classify ct id @high_throughput return"
+	post_include "add rule inet dscpclassify dynamic_classify ct packets < 8 return"
+	post_include "add rule inet dscpclassify dynamic_classify ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
+	post_include "add rule inet dscpclassify dynamic_classify ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
+	post_include "add rule inet dscpclassify dynamic_classify ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"
+
+	post_include "add rule inet dscpclassify dynamic_classify_reply th sport { 80, 443 } return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply meter ht_reply_pps { ct id limit rate over $realtime_max_pps/second burst 100 packets } update @high_throughput { ct id timeout 30s } ct mark set ct mark and \$ct_unused_dyn or \$cs0 return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ct id @high_throughput return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ct packets < 8 return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ct original avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ct reply avgpkt > $realtime_max_avgpkt ct mark set ct mark and \$ct_unused_dyn or \$$class_video_conference return"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ct mark set ct mark and \$ct_unused_dyn or \$$class_realtime"
 }
 
 create_dscp_mark_rule() {
 	local wmm
 
-	config_get_bool wmm globals wmm 1
+	config_get_bool wmm global wmm 1
 	[ "$wmm" = 1 ] && {
 		post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark and \$ct_dscp vmap @ct_wmm"
 	}
@@ -465,6 +495,9 @@ create_dscp_mark_rule() {
 
 create_pre_include() {
 	rm -f "/tmp/etc/dscpclassify-pre.include"
+
+	config_get lan global lan "$lan"
+	config_get wan global wan "$wan"
 
 	pre_include "define lan = { $(mklist "$lan") }"
 	pre_include "define wan = { $(mklist "$wan") }"
@@ -480,7 +513,7 @@ create_post_include() {
 
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
-	create_dynamic_realtime_rule || return 1
+	create_dynamic_rule || return 1
 
 	create_dscp_mark_rule || return 1
 }
@@ -494,7 +527,7 @@ setup() {
 
 	create_pre_include || return 1
 	create_post_include || return 1
-	nft -f /etc/dscpclassify.d/main.nft || return 1
+	nft -f "/etc/dscpclassify.d/main.nft" || return 1
 	rm -f "/tmp/etc/dscpclassify-pre.include"
 	rm -f "/tmp/etc/dscpclassify-post.include"
 


### PR DESCRIPTION
- Dynamic classification chain only applies to connections that have received at least one response.
- Classified threaded connection packets no longer need to keep passing through the dynamic classification set (reduced load particularly for P2P traffic).
- A connection's dynamic classification is fixed after a 1m evaluation period.

@ldir-EDB0 I'll likely tweak default timings and make them configurable before merging into main.