### PR TITLE
Refactor of dynamic classification logic (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Connections that do not match a pre-specified rule will be dynamically classifie
   * These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
 * Multi-connection service detection for identifying high-throughput downloads from services such as Steam/Windows Update
   * These connections are classified as High-Throughput (AF13) by default and therefore have a higher drop probability than regular traffic in the Best Effort layer-cake tin.
-* Increased priority for low throughput small packet UDP streams such as VoIP/game traffic.
-  * These connections are classified as Real-Time (CS4) by default and are processed by layer-cake in the Voice tin.
-  
+
 ### External classification
 The service will respect DSCP classification stored by an external service in a connection's conntrack bits, this could include services such as netifyd.
 
@@ -70,13 +68,11 @@ A working default configuration is provided with the service.
 
 |  Config option | Description  | Type  | Default  |
 |---|---|---|---|
+| class_bulk | The class applied to threaded bulk clients | string | le |
+| class_high_throughput | The class applied to threaded high-throughput services | string | af13 |
 | client_hints | Adopt the DSCP class supplied by a non-WAN client (this exludes CS6 and CS7 classes to avoid abuse) | boolean | 1 |
-| threaded_client_kbps | The rate in kBps when a threaded client port (i.e. P2P) is classified as bulk | uint | 10 |
-| threaded_client_class | The class applied to threaded bulk clients | string | le |
-| threaded_service_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
-| threaded_service_class | The class applied to threaded high-throughput services | string | af13 |
-| dynamic_realtime_class | The class applied to dynamic real-time connections | string | cs4 |
-| unclassified_bytes | The total bytes before an unclassified connection is ignored by the dynamic classifier | uint | 5 * threaded_service_bytes |
+| threaded_client_min_bytes | The total bytes before a threaded client port (i.e. P2P) is classified as bulk | uint | 10000 |
+| threaded_service_min_bytes | The total bytes before a threaded service's connection is classed as high-throughput | uint | 1000000 |
 | wmm | When enabled the service will mark LAN bound packets with DSCP values respective of WMM (RFC-8325) | boolean |  1 |
 
 **Below is an example user rule:**

--- a/etc/config/dscpclassify
+++ b/etc/config/dscpclassify
@@ -1,10 +1,9 @@
 config global 'global'
+	option class_bulk 'le'
+	option class_high_throughput 'af13'
 	option client_hints '1'
-	option threaded_client_kbps '10'
-	option threaded_client_class 'le'
-	option threaded_service_bytes '1000000'
-	option threaded_service_class 'af13'
-	option dynamic_realtime_class 'cs4'
+	option threaded_client_min_bytes '10000'
+	option threaded_service_min_bytes '1000000'
 	option wmm '1'
 
 config set

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -6,9 +6,10 @@ include "/tmp/etc/dscpclassify-pre.include"
 ## Masks for extracting/storing data in the conntrack mark
 define ct_dscp = 0x0000003f
 define ct_dyn = 0x00000080
-define ct_dyn_dscp = 0x000000ff
-define ct_unclassified = 0x00000040
+define ct_dyn_static_dscp = 0x000000ff
+define ct_static = 0x00000040
 define ct_unused = 0xffffff00
+define ct_unused_dscp = 0xffffff3f
 define ct_unused_dyn = 0xffffff80
 
 ## DSCP classification values
@@ -131,7 +132,7 @@ table inet dscpclassify {
     chain input {
         type filter hook input priority 2; policy accept
         meta iifname "lo" return
-        ct mark and $ct_dyn_dscp == 0 ct direction original jump static_classify
+        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
     }
 
@@ -139,7 +140,7 @@ table inet dscpclassify {
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
         meta oifname "lo" return
-        ct mark and $ct_dyn_dscp == 0 ct direction original jump static_classify
+        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
 
         ## DSCP marking rules are added here by the init script
@@ -148,53 +149,61 @@ table inet dscpclassify {
     chain static_classify {
         ## User defined rules in '/etc/config/dscpclassify' are inserted here by the init script
 
-        ## Unclassified packets get dynamic conntrack mark
+        ## Non TCP/UDP unclassified connections are Best Effort (CS0)
+        meta l4proto != { tcp, udp } goto ct_set_cs0
+
+        ## Set the dynamic conntrack bit on unclassified connections
         ct mark set ct mark and $ct_unused or $ct_dyn
     }
 
     chain dynamic_classify {
-        # Ignore non TCP/UDP connections
-        meta l4proto != { tcp, udp } goto ct_set_cs0
+        ## Unreplied connections are ignored by dynamic classification logic
+        ct status and seen-reply != seen-reply return
 
-        ## Detect connection threading by counting connections opened within a time period
-        ct packets 1 goto detect_threading
-
-        ## Non-established connections are ignored by dynamic classification logic
-        ct state new return
+        ## Handle connection replies
+        ct direction reply goto dynamic_classify_reply
 
         ## Assess threaded client connections (i.e. P2P) for classification
-        meta l4proto . ip saddr . th sport @threaded_clients goto threaded_client
-        meta l4proto . ip6 saddr . th sport @threaded_clients6 goto threaded_client
-        meta l4proto . ip daddr . th dport @threaded_clients goto threaded_client_response
-        meta l4proto . ip6 daddr . th dport @threaded_clients6 goto threaded_client_response
+        ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
+        ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client
 
         ## Assess threaded service connections for classification
-        meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport @threaded_services goto threaded_service
-        meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport @threaded_services6 goto threaded_service
-        meta l4proto . ip daddr . ip saddr and 255.255.255.0 . th sport @threaded_services goto threaded_service_response
-        meta l4proto . ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport @threaded_services6 goto threaded_service_response
+        ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
+        ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
 
-        ## Assess UDP connections for real-time classification
-        meta l4proto udp th dport != { 80, 443 } th sport != { 80, 443 } jump dynamic_realtime
-
-        ## The unclassified connection rule is added here by the init script
+        ## Dynamic rules are added here by the init script
     }
 
-    chain detect_threading {
+    chain dynamic_classify_reply {
+        ## Established connection
+        ct reply packets 1 jump established_connection
+
+        ## Assess threaded client connections (i.e. P2P) for classification
+        ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
+        ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply
+
+        ## Assess threaded service connections for classification
+        ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
+        ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
+
+        ## Dynamic rules are added here by the init script
+    }
+
+    chain established_connection {
         ## Detect multiple connections being opened from a single source port (i.e. P2P)
-        meter tcdetect { meta l4proto . ip saddr . th sport timeout 5s limit rate over 10/minute } add @threaded_clients { meta l4proto . ip saddr . th sport timeout 5s }
-        meter tcdetect6 { meta l4proto . ip6 saddr . th sport timeout 5s limit rate over 10/minute } add @threaded_clients6 { meta l4proto . ip6 saddr . th sport timeout 5s }
+        meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+        meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 10/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }
 
         ## Detect multiple connections being opened to a service from a single source address
-        meter tsdetect { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 5s limit rate over 2/minute } add @threaded_services { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 20s }
-        meter tsdetect6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 5s limit rate over 2/minute } add @threaded_services6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 20s }
+        meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }
+        meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
     }
 
     chain threaded_client {
         ## Threaded client rules are added here by the init script
     }
 
-    chain threaded_client_response {
+    chain threaded_client_reply {
         ## Threaded client rules are added here by the init script
     }
 
@@ -202,50 +211,33 @@ table inet dscpclassify {
         ## Threaded service rules are added here by the init script
     }
 
-    chain threaded_service_response {
+    chain threaded_service_reply {
         ## Threaded service rules are added here by the init script
-    }
-
-    chain dynamic_realtime {
-        ## Classify high-throughput connections exceeding 200pps as Best Effort (CS0)
-        meter htdetect { ip saddr . th sport . ip daddr . th dport limit rate over 200/second burst 100 packets } update @high_throughput { ip saddr . th sport . ip daddr . th dport timeout 5s } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-        meter htdetect6 { ip6 saddr . th sport . ip6 daddr . th dport limit rate over 200/second burst 100 packets } update @high_throughput6 { ip6 saddr . th sport . ip6 daddr . th dport timeout 5s } ct mark set ct mark and $ct_unused_dyn or $cs0 return
-
-        ## Return high-throughput connection responses
-        ip daddr . th dport . ip saddr . th sport @high_throughput return
-        ip6 daddr . th dport . ip6 saddr . th sport @high_throughput6 return
-
-        ## Dynamic real-time rules are added here by the init script
     }
 
     ## Sets for stateful tracking
     set threaded_clients {
-        type inet_proto . ipv4_addr . inet_service
+        type ipv4_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_clients6 {
-        type inet_proto . ipv6_addr . inet_service
+        type ipv6_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_services {
-        type inet_proto . ipv4_addr . ipv4_addr . inet_service
+        type ipv4_addr . ipv4_addr . inet_service . inet_proto
         flags timeout
     }
 
     set threaded_services6 {
-        type inet_proto . ipv6_addr . ipv6_addr . inet_service
+        type ipv6_addr . ipv6_addr . inet_service . inet_proto
         flags timeout
     }
 
     set high_throughput {
-        type ipv4_addr . inet_service . ipv4_addr . inet_service
-        flags timeout
-    }
-
-    set high_throughput6 {
-        type ipv6_addr . inet_service . ipv6_addr . inet_service
+        typeof ct id
         flags timeout
     }
 
@@ -367,7 +359,7 @@ table inet dscpclassify {
 
     ## Set conntrack DSCP mark without modifying unused bits
     chain ct_set_cs0 {
-        ct mark set ct mark and $ct_unused or $cs0 or $ct_unclassified
+        ct mark set ct mark and $ct_unused or $cs0 or $ct_static
     }
 
     chain ct_set_le {

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -45,6 +45,11 @@ check_class() {
 	class="$(echo "$1" | tr 'A-Z' 'a-z')"
 	[ "$class" = "be" ] && class="cs0"
 
+	if [ "$2" = "var" ] && [ "$class" = "le" ]; then
+		echo "lephb"
+		return 0
+	fi
+
 	case "$class" in
 	cs0 | le | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7)
 		echo "$class"
@@ -321,7 +326,7 @@ create_user_set() {
 		return 1
 	}
 	case $name in
-	threaded_clients | threaded_clients6 | threaded_services | threaded_services6 | high_throughput | high_throughput6)
+	high_throughput | threaded_clients | threaded_clients6 | threaded_services | threaded_services6)
 		log warning "Config sets cannot overwrite built-in dscpclassify sets"
 		return 1
 		;;
@@ -388,92 +393,61 @@ create_user_rule() {
 create_client_hints_rule() {
 	local client_hints
 
-	config_get_bool client_hints globals client_hints 1
+	config_get_bool client_hints global client_hints 1
 	[ "$client_hints" = 1 ] || return 0
 
-	post_include "insert rule inet dscpclassify static_classify iifname != \$wan ip6 dscp != { cs0, cs6, cs7 } ip6 dscp vmap @dscp_ct"
-	post_include "insert rule inet dscpclassify static_classify iifname != \$wan ip dscp != { cs0, cs6, cs7 } ip dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != \$wan ip6 dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify static_classify ip dscp != { cs0, cs6, cs7 } iifname != \$wan ip dscp vmap @dscp_ct"
 }
 
 create_threaded_client_rule() {
-	local threaded_client_class threaded_client_kbps
+	local class_bulk threaded_client_min_bytes
 
-	config_get_uint threaded_client_kbps globals threaded_client_kbps 10 || {
-		log error "Global option threaded_client_kbps contains an invalid number"
+	config_get_uint threaded_client_min_bytes global threaded_client_min_bytes 10000 || {
+		log error "Global option threaded_client_min_bytes contains an invalid number"
 		return 1
 	}
-	config_get threaded_client_class globals threaded_client_class le
-	threaded_client_class="$(check_class "$threaded_client_class")" || {
-		log error "Global option threaded_client_class contains an invalid DSCP class"
+	config_get class_bulk global class_bulk le
+	class_bulk="$(check_class "$class_bulk")" || {
+		log error "Global option class_bulk contains an invalid DSCP class"
 		return 1
 	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
 
-	post_include "add rule inet dscpclassify threaded_client meter tcbulk { meta l4proto . ip saddr . th sport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients { meta l4proto . ip saddr . th sport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client meter tcbulk6 { meta l4proto . ip6 saddr . th sport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients6 { meta l4proto . ip6 saddr . th sport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 
-	post_include "add rule inet dscpclassify threaded_client_response meter tcrbulk { meta l4proto . ip daddr . th dport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients { meta l4proto . ip daddr . th dport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
-	post_include "add rule inet dscpclassify threaded_client_response meter tcrbulk6 { meta l4proto . ip6 daddr . th dport limit rate over $threaded_client_kbps kbytes/second } update @threaded_clients6 { meta l4proto . ip6 daddr . th dport timeout 5m } ct mark set ct mark and \$ct_unused_dyn or \$$threaded_client_class"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $threaded_client_min_bytes bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 }
 
 create_threaded_service_rule() {
-	local threaded_service_bytes threaded_service_class
+	local class_high_throughput threaded_service_min_bytes
 
-	config_get_uint threaded_service_bytes globals threaded_service_bytes 1000000 || {
-		log error "Global option threaded_service_bytes contains an invalid number"
+	config_get_uint threaded_service_min_bytes global threaded_service_min_bytes 1000000 || {
+		log error "Global option threaded_service_min_bytes contains an invalid number"
 		return 1
 	}
-	config_get threaded_service_class globals threaded_service_class af13
-	threaded_service_class="$(check_class "$threaded_service_class")" || {
-		log error "Global option threaded_service_class contains an invalid DSCP class"
-		return 1
-	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
-
-	post_include "add rule inet dscpclassify threaded_service ct bytes < $threaded_service_bytes return"
-	post_include "add rule inet dscpclassify threaded_service ct mark set ct mark and \$ct_unused_dyn or \$$threaded_service_class"
-	post_include "add rule inet dscpclassify threaded_service update @threaded_services { meta l4proto . ip saddr . ip daddr and 255.255.255.0 . th dport timeout 60s }"
-	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { meta l4proto . ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport timeout 60s }"
-
-	post_include "add rule inet dscpclassify threaded_service_response ct bytes < $threaded_service_bytes return"
-	post_include "add rule inet dscpclassify threaded_service_response ct mark set ct mark and \$ct_unused_dyn or \$$threaded_service_class"
-	post_include "add rule inet dscpclassify threaded_service_response update @threaded_services { meta l4proto . ip daddr . ip saddr and 255.255.255.0 . th sport timeout 60s }"
-	post_include "add rule inet dscpclassify threaded_service_response update @threaded_services6 { meta l4proto . ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport timeout 60s }"
-}
-
-create_dynamic_realtime_rule() {
-	local dynamic_realtime_class
-
-	config_get dynamic_realtime_class globals dynamic_realtime_class cs4
-	dynamic_realtime_class="$(check_class "$dynamic_realtime_class")" || {
-		log error "Global option dynamic_realtime_class contains an invalid DSCP class"
-		return 1
-	}
-	[ "$threaded_client_class" = "le" ] && threaded_client_class="lephb"
-
-	post_include "add rule inet dscpclassify dynamic_realtime ct avgpkt 0-450 ct mark set ct mark and \$ct_unused_dyn or \$$dynamic_realtime_class return"
-	post_include "add rule inet dscpclassify dynamic_realtime ct mark set ct mark and \$ct_unused_dyn or \$cs0"
-}
-
-create_unclassified_rule() {
-	local threaded_service_bytes unclassified_bytes
-
-	config_get_uint threaded_service_bytes globals threaded_service_bytes 1000000 || {
-		log error "Global option threaded_service_bytes contains an invalid number"
-		return 1
-	}
-	config_get_uint unclassified_bytes globals unclassified_bytes $((5 * threaded_service_bytes)) || {
-		log error "Global option unclassified_bytes contains an invalid number"
+	config_get class_high_throughput global class_high_throughput af13
+	class_high_throughput="$(check_class "$class_high_throughput")" || {
+		log error "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
 	}
 
-	post_include "add rule inet dscpclassify dynamic_classify ct mark and \$ct_dscp == 0 ct bytes > $unclassified_bytes goto ct_set_cs0"
+	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service goto ct_set_$class_high_throughput"
+
+	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_$class_high_throughput"
 }
 
 create_dscp_mark_rule() {
 	local wmm
 
-	config_get_bool wmm globals wmm 1
+	config_get_bool wmm global wmm 1
 	[ "$wmm" = 1 ] && {
 		post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark and \$ct_dscp vmap @ct_wmm"
 	}
@@ -482,6 +456,9 @@ create_dscp_mark_rule() {
 
 create_pre_include() {
 	rm -f "/tmp/etc/dscpclassify-pre.include"
+
+	config_get lan global lan "$lan"
+	config_get wan global wan "$wan"
 
 	pre_include "define lan = { $(mklist "$lan") }"
 	pre_include "define wan = { $(mklist "$wan") }"
@@ -497,8 +474,6 @@ create_post_include() {
 
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
-	create_dynamic_realtime_rule || return 1
-	create_unclassified_rule || return 1
 
 	create_dscp_mark_rule || return 1
 }
@@ -512,7 +487,7 @@ setup() {
 
 	create_pre_include || return 1
 	create_post_include || return 1
-	nft -f /etc/dscpclassify.d/main.nft || return 1
+	nft -f "/etc/dscpclassify.d/main.nft" || return 1
 	rm -f "/tmp/etc/dscpclassify-pre.include"
 	rm -f "/tmp/etc/dscpclassify-post.include"
 


### PR DESCRIPTION
* Refactor dynamic classification logic, update config params to make names clearer

* Remove dynamic classification logic based on rate/bytes, following testing this creates too many false positives. Cake already handles this well natively for non-threaded connections.