### PR TITLE
Enhance logging for invalid config by adding $name to log message

### DIFF
--- a/dscpclassify-post.include
+++ b/dscpclassify-post.include
@@ -1,0 +1,41 @@
+insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != $wan ip6 dscp vmap @dscp_ct
+insert rule inet dscpclassify static_classify ip dscp != { cs0, cs6, cs7 } iifname != $wan ip dscp vmap @dscp_ct
+add set inet dscpclassify xcloud { type ipv4_addr;   flags interval; auto-merge;  }
+add element inet dscpclassify xcloud { 13.104.0.0/14 }
+add set inet dscpclassify GeForceNOWIPv4 { type ipv4_addr;   flags interval; auto-merge;  }
+add element inet dscpclassify GeForceNOWIPv4 { 80.84.160.0/20 }
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 88.82.11.0/24 } th dport { 4500 }   th sport { 4500 } counter goto ct_set_ef comment "Vodafone UK WiFiCall ESP"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  th dport { 3478 }   counter goto ct_set_af41 comment "STUN various"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 95.172.238.85 }     counter goto ct_set_ef comment "Voipify VoIP"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }    th dport != { 80, 443 }  ip saddr { 192.168.1.100 }  counter goto ct_set_cs4 comment "Game Console non-HTTP"
+insert rule inet dscpclassify static_classify  meta l4proto { icmp }     counter goto ct_set_cs5 comment "ICMP"
+insert rule inet dscpclassify static_classify    ip daddr { 17.0.0.0/8 }    th sport { 16384-16387, 16393-16402 } counter goto ct_set_af41 comment "Apple FaceTime"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 }     counter goto ct_set_ef comment "Discord VoIP"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } th dport { 3478-3481 }   th sport { 50040-50059 } counter goto ct_set_af21 comment "Microsoft Teams sharing"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } th dport { 3478-3481 }   th sport { 50020-50039 } counter goto ct_set_af41 comment "Microsoft Teams video"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } th dport { 3478-3481 }   th sport { 50000-50019 } counter goto ct_set_ef comment "Microsoft Teams voice"
+insert rule inet dscpclassify static_classify meta nfproto { ipv4 } meta l4proto { udp }   ip daddr  @GeForceNOWIPv4    th sport { 49003-49006 } counter goto ct_set_af41 comment "NVIDIA GFN"
+insert rule inet dscpclassify static_classify meta nfproto { ipv4 } meta l4proto { udp }   ip daddr  @xcloud th dport { 1000-1150, 9002 }    counter goto ct_set_af41 comment "Xbox Cloud Gaming"
+insert rule inet dscpclassify static_classify  meta l4proto { tcp }  th dport { 22 }   counter goto ct_set_cs2 comment "SSH"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  th dport { 123 }   counter goto ct_set_cs5 comment "NTP"
+insert rule inet dscpclassify static_classify  meta l4proto { udp }  th dport { 67, 68 }   counter goto ct_set_cs5 comment "BOOTP/DHCP"
+insert rule inet dscpclassify static_classify  meta l4proto { tcp, udp }  ip daddr { 8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1, 9.9.9.9, 149.112.112.112, 9.9.9.11, 149.112.112.11, 94.140.14.0/24 } th dport { 443 }    counter goto ct_set_cs5 comment "DoH"
+insert rule inet dscpclassify static_classify  meta l4proto { tcp, udp }  th dport { 53, 853, 5353 }   counter goto ct_set_cs5 comment "DNS"
+add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }
+add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }
+add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
+add rule inet dscpclassify threaded_service ct original bytes < 1000000 return
+add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }
+add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }
+add rule inet dscpclassify threaded_service goto ct_set_af13
+add rule inet dscpclassify threaded_service_reply ct reply bytes < 1000000 return
+add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }
+add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }
+add rule inet dscpclassify threaded_service_reply goto ct_set_af13
+add rule inet dscpclassify postrouting oifname $lan ct mark and $ct_dscp vmap @ct_wmm
+add rule inet dscpclassify postrouting ct mark and $ct_dscp vmap @ct_dscp

--- a/dscpclassify-pre.include
+++ b/dscpclassify-pre.include
@@ -1,0 +1,9 @@
+define lan = { "br-lan", "br-swlan", "eth2" }
+define wan = { "eth0", "eth5" }
+add table inet dscpclassify
+add set inet dscpclassify threaded_clients { type ipv4_addr . inet_service . inet_proto; flags timeout; }
+add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }
+add set inet dscpclassify threaded_services { type ipv4_addr . ipv4_addr . inet_service . inet_proto; flags timeout; }
+add set inet dscpclassify threaded_services6 { type ipv6_addr . ipv6_addr . inet_service . inet_proto; flags timeout; }
+include "/etc/dscpclassify.d/verdicts.nft"
+include "/etc/dscpclassify.d/maps.nft"

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -139,7 +139,7 @@ check_set_size() {
 	[ -n "$1" ] || return 0
 
 	if ! [ "$1" -ge 1 ] 2>/dev/null || ! [ "$1" -le 65535 ] 2>/dev/null; then
-		log warning "Set contains an invalid maxelem option"
+		log warning "Set '$name' contains an invalid maxelem option"
 		return 1
 	fi
 
@@ -240,7 +240,7 @@ parse_set_timeout() {
 	}
 
 	check_duration "$timeout" || {
-		log warning "Set contains an invalid timeout option"
+		log warning "Set '$name' contains an invalid timeout option"
 		return 1
 	}
 
@@ -280,7 +280,7 @@ parse_set_type() {
 		case "$i" in
 		src_* | dest_*) true ;;
 		*)
-			log warning "Set contains an invalid match option"
+			log warning "Set '$name' contains an invalid match option"
 			return 1
 			;;
 		esac
@@ -294,7 +294,7 @@ parse_set_type() {
 			flag_interval=1
 			;;
 		*)
-			log warning "Set contains an invalid match option"
+			log warning "Set '$name' contains an invalid match option"
 			return 1
 			;;
 		esac
@@ -373,7 +373,7 @@ rule_zone() {
 	[ -n "$2" ] || return 0
 
 	device="$(fw_zone_dev "$2")" || {
-		log warning "Rule contains an invalid $1 zone"
+		log warning "Rule '$name' contains an invalid $1 zone"
 		return 1
 	}
 
@@ -402,7 +402,7 @@ rule_port() {
 	[ -n "$2" ] || return 0
 
 	parse_rule_ports "$2" || {
-		log warning "Rule contains an invalid $1_port"
+		log warning "Rule '$name' contains an invalid $1_port"
 		return 1
 	}
 	check_port_proto "$3" || {
@@ -434,11 +434,11 @@ rule_addr() {
 	[ -n "$2" ] || return 0
 
 	if [ -n "$3" ] && ! check_family "$3"; then
-		log warning "Rule contains an invalid family"
+		log warning "Rule '$name' contains an invalid family"
 		return 1
 	fi
 	parse_rule_ips "$2" || {
-		log warning "Rule contains an invalid $1_ip"
+		log warning "Rule '$name' contains an invalid $1_ip"
 		return 1
 	}
 	if [ -n "$ipset$ipset_negate" ] && [ -n "$ipv4$ipv6$ipv4_negate$ipv6_negate" ]; then
@@ -510,7 +510,7 @@ rule_verdict() {
 		return 1
 	}
 	class="$(check_class "$1")" || {
-		log warning "Rule contains an invalid DSCP class"
+		log warning "Rule '$name' contains an invalid DSCP class"
 		return 1
 	}
 
@@ -577,17 +577,17 @@ create_threaded_client_rule() {
 
 	config_get threaded_client_min_connections global threaded_client_min_connections 10
 	if ! check_uint "$threaded_client_min_connections" || [ "$threaded_client_min_connections" -lt 2 ]; then
-		log err "Global option threaded_client_min_connections contains an invalid value"
+		log err "Global option 'threaded_client_min_connections' contains an invalid value"
 		return 1
 	fi
 	config_get threaded_client_min_bytes global threaded_client_min_bytes 10000
 	if ! check_uint "$threaded_client_min_bytes" || [ "$threaded_client_min_bytes" = 0 ]; then
-		log err "Global option threaded_client_min_bytes contains an invalid value"
+		log err "Global option 'threaded_client_min_bytes' contains an invalid value"
 		return 1
 	fi
 	config_get class_bulk global class_bulk le
 	class_bulk="$(check_class "$class_bulk")" || {
-		log err "Global option class_bulk contains an invalid DSCP class"
+		log err "Global option 'class_bulk' contains an invalid DSCP class"
 		return 1
 	}
 
@@ -606,17 +606,17 @@ create_threaded_service_rule() {
 
 	config_get threaded_service_min_connections global threaded_service_min_connections 3
 	if ! check_uint "$threaded_service_min_connections" || [ "$threaded_service_min_connections" -lt 2 ]; then
-		log err "Global option threaded_service_min_connections contains an invalid value"
+		log err "Global option 'threaded_service_min_connections' contains an invalid value"
 		return 1
 	fi
 	config_get threaded_service_min_bytes global threaded_service_min_bytes 1000000
 	check_uint "$threaded_service_min_bytes" || {
-		log err "Global option threaded_service_min_bytes contains an invalid value"
+		log err "Global option 'threaded_service_min_bytes' contains an invalid value"
 		return 1
 	}
 	config_get class_high_throughput global class_high_throughput af13
 	class_high_throughput="$(check_class "$class_high_throughput")" || {
-		log err "Global option class_high_throughput contains an invalid DSCP class"
+		log err "Global option 'class_high_throughput' contains an invalid DSCP class"
 		return 1
 	}
 

--- a/etc/init.d/dscpclassify.main
+++ b/etc/init.d/dscpclassify.main
@@ -1,0 +1,754 @@
+#!/bin/sh /etc/rc.common
+# shellcheck disable=SC3043,SC3003,SC2019,SC2018,SC3020,SC3057
+
+START=20
+USE_PROCD=1
+DEBUG=0
+
+log() {
+	logger -t dscpclassify -p "daemon.$1" "$2"
+}
+
+create_path() {
+	mkdir -p "$1" && return 0
+	log err "Unable to create '$1' path"
+	return 1
+}
+
+delete_includes() {
+	rm -f "/tmp/etc/dscpclassify-pre.include"
+	rm -f "/tmp/etc/dscpclassify-post.include"
+}
+
+delete_table() {
+	nft delete table inet dscpclassify 2>/dev/null
+}
+
+cleanup() {
+	delete_includes
+	delete_table
+}
+
+pre_include() {
+	echo "$1" >>"/tmp/etc/dscpclassify-pre.include"
+}
+
+post_include() {
+	echo "$1" >>"/tmp/etc/dscpclassify-post.include"
+}
+
+list_append() {
+	list="$list"$'\n'"$1"
+}
+
+config_foreach_reverse() {
+	local list
+
+	config_foreach list_append "$2"
+	list=$(echo "$list" | sort -r)
+
+	for config in $list; do
+		"$1" "$config" "$3"
+	done
+}
+
+fw_zone_dev() {
+	local dev
+
+	dev="$(fw4 -q zone "$1" | sort -u)"
+	[ -n "$dev" ] || return 1
+
+	echo "$dev"
+	return 0
+}
+
+mklist() {
+	echo "$1" | tr '\n' ' ' | sed -e "s/^\s*/$3/" -e "s/\s*$/$3/" -e "s/\([^.]\)\s\+\([^.]\)/\1$3$2$3\2/g"
+}
+
+check_class() {
+	local class
+
+	class="$(echo "$1" | tr 'A-Z' 'a-z')"
+
+	case "$class" in
+	le) [ "$2" = "var" ] && class="lephb" ;;
+	be | df) class="cs0" ;;
+	cs0 | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7) true ;;
+	*) return 1 ;;
+	esac
+
+	echo "$class"
+	return 0
+}
+
+check_duration() {
+	echo "$1" | grep -q -E -e "^([1-9][0-9]*[smhd]){1,4}$"
+}
+
+convert_duration_to_seconds() {
+	local duration seconds
+
+	duration="$(echo "$1" | sed -e 's/\([dhms]\)/\1 /g')"
+	for i in $duration; do
+		case "$i" in
+		*d) seconds=$((seconds + ${i::-1} * 86400)) || return 1 ;;
+		*h) seconds=$((seconds + ${i::-1} * 3600)) || return 1 ;;
+		*m) seconds=$((seconds + ${i::-1} * 60)) || return 1 ;;
+		*s) seconds=$((seconds + ${i::-1})) || return 1 ;;
+		*) return 1 ;;
+		esac
+	done
+
+	echo "$seconds"
+}
+
+check_family() {
+	case "$1" in
+	ipv4 | ipv6) return 0 ;;
+	esac
+
+	return 1
+}
+
+check_port_proto() {
+	for i in $1; do
+		case "$i" in
+		tcp | udp) true ;;
+		*) return 1 ;;
+		esac
+	done
+}
+
+check_set_name() {
+	case "$1" in
+	"")
+		log warning "Set is missing the name option"
+		return 1
+		;;
+	threaded_clients | threaded_clients6 | threaded_services | threaded_services6)
+		log warning "Sets cannot overwrite built-in dscpclassify sets"
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
+check_set_size() {
+	[ -n "$1" ] || return 0
+
+	if ! [ "$1" -ge 1 ] 2>/dev/null || ! [ "$1" -le 65535 ] 2>/dev/null; then
+		log warning "Set '$name' contains an invalid maxelem option"
+		return 1
+	fi
+
+	return 0
+}
+
+check_set_exists() {
+	nft -t list set inet dscpclassify "$1" &>/dev/null
+}
+
+check_set_against_existing() {
+	local name type comment size flags timeout
+	local existing_set existing_type
+
+	name="$1"
+	existing_set=$(nft -t -j list set inet dscpclassify "$name" 2>/dev/null) || return 2
+
+	type="$(echo "$2" | sed 's/ \+\. \+/ /g')"
+	existing_type="$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.type")"
+	if [ -n "$existing_type" ]; then
+		[ "$existing_type" = "$type" ] || return 1
+	else
+		existing_type="$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.type[*]" | tr '\n' ' ' | sed 's/ *$//')"
+		[ "$existing_type" = "$type" ] || return 1
+	fi
+
+	comment="$3"
+	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.comment")" = "$comment" ] || return 1
+
+	size="$4"
+	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.size")" = "$size" ] || return 1
+
+	flags="$(echo "$5" | sed 's/, \+/ /g')"
+	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.flags[*]" | tr '\n' ' ' | sed 's/ *$//')" = "$flags" ] || return 1
+
+	timeout="$(convert_duration_to_seconds "$6")"
+	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.timeout")" = "$timeout" ] || return 1
+
+	return 0
+}
+
+check_uint() {
+	[ "$1" -ge 0 ] 2>/dev/null && return 0
+	return 1
+}
+
+parse_rule_ports() {
+	for i in $1; do
+		echo "$i" | grep -q -E -e "^!?[1-9][0-9]*(-[1-9][0-9]*)?$" || return 1
+		case "$i" in
+		"!"*) port_negate="$port_negate ${i#*!}" ;;
+		*) port="$port $i" ;;
+		esac
+	done
+}
+
+parse_rule_ips() {
+	for i in $1; do
+		echo "$i" | grep -q -E -e "^!?(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9])[.]){3}(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9]))(/([0-9]|[12][0-9]|3[0-2]))?$" && {
+			case "$i" in
+			"!"*) ipv4_negate="$ipv4_negate ${i#*!}" ;;
+			*) ipv4="$ipv4 $i" ;;
+			esac
+			continue
+		}
+
+		echo "$i" | grep -q -E -e "^!?(([a-fA-F0-9]{1,4}|):){1,7}([a-fA-F0-9]{1,4}|:)(/[0-9]{1,3})?$" && {
+			case "$i" in
+			"!"*) ipv6_negate="$ipv6_negate ${i#*!}" ;;
+			*) ipv6="$ipv6 $i" ;;
+			esac
+			continue
+		}
+
+		echo "$i" | grep -q -E -e "^!?@\w+$" && {
+			case "$i" in
+			"!"*) ipset_negate="$ipset_negate ${i#*!}" ;;
+			*) ipset="$ipset $i" ;;
+			esac
+			continue
+		}
+		return 1
+	done
+}
+
+parse_set_timeout() {
+	[ -n "$timeout" ] || return 0
+
+	[ "$timeout" = 0 ] && {
+		flag_timeout=1
+		timeout=""
+		return 0
+	}
+
+	check_uint "$timeout" && {
+		flag_timeout=1
+		timeout="${timeout}s"
+	}
+
+	check_duration "$timeout" || {
+		log warning "Set '$name' contains an invalid timeout option"
+		return 1
+	}
+
+	return 0
+}
+
+parse_set_flags() {
+	[ "$flag_constant" = 1 ] && {
+		flags="$flags constant"
+	}
+
+	[ "$flag_interval" = 1 ] && {
+		flags="$flags interval"
+		auto_merge=1
+	}
+
+	[ "$flag_timeout" = 1 ] && {
+		flags="$flags timeout"
+	}
+
+	[ -n "$flags" ] && flags="$(mklist "$flags" ", ")"
+
+	return 0
+}
+
+parse_set_type() {
+	[ -n "$type" ] && return 0
+
+	[ -n "$match" ] || {
+		type="${family}_addr"
+		return 0
+	}
+
+	log warning "The match set option functionality is not yet fully implemented for user sets"
+
+	for i in $match; do
+		case "$i" in
+		src_* | dest_*) true ;;
+		*)
+			log warning "Set '$name' contains an invalid match option"
+			return 1
+			;;
+		esac
+
+		case "$i" in
+		*_ip) type="$type ${family}_addr" ;;
+		*_mac) type="$type ether_addr" ;;
+		*_port) type="$type inet_service" ;;
+		*_net)
+			type="$type ${family}_addr"
+			flag_interval=1
+			;;
+		*)
+			log warning "Set '$name' contains an invalid match option"
+			return 1
+			;;
+		esac
+	done
+	type=$(mklist "$type" " . ")
+
+	return 0
+}
+
+create_user_set() {
+	local comment entry element enabled family flags match size name timeout type
+	local flag_constant flag_interval flag_timeout auto_merge
+
+	config_get_bool enabled "$1" enabled 1
+	[ "$enabled" = 1 ] || return 0
+
+	config_get comment "$1" comment
+	config_get name "$1" name
+	config_get family "$1" family ipv4
+	config_get match "$1" match
+	config_get type "$1" type # allows user to explicity specify the nft set type
+	config_get size "$1" maxelem
+	config_get timeout "$1" timeout
+
+	config_get_bool flag_constant "$1" constant
+	config_get_bool flag_interval "$1" interval
+
+	config_get entry "$1" entry
+	config_get element "$1" element # depreciate for naming consistency with fw4 (entry)
+	[ -n "$element" ] && log warning "The user set 'element' option is being depreciated in favour of 'entry' for consistency with fw4"
+
+	check_set_name "$name" || return 1
+	check_set_size "$size" || return 1
+	check_family "$family" || {
+		log warning "Set contains an invalid family"
+		return 1
+	}
+
+	parse_set_type || return 1
+	parse_set_timeout || return 1
+	parse_set_flags || return 1
+
+	check_set_against_existing "$name" "$type" "$comment" "$size" "$flags" "$timeout" || {
+		[ "$?" = 1 ] && post_include "delete set inet dscpclassify $name"
+		post_include "add set inet dscpclassify $name { type $type; ${timeout:+timeout $timeout;} ${size:+size $size;} ${flags:+flags $flags;} ${auto_merge:+auto-merge;} ${comment:+comment \"$comment\";} }"
+	}
+
+	[ -n "$entry$element" ] && post_include "add element inet dscpclassify $name { $(mklist "$entry $element" ", ") }"
+
+	return 0
+}
+
+rule_l4proto() {
+	[ -n "$1" ] || return 0
+	l4proto="meta l4proto { $(mklist "$1" ", ") }"
+}
+
+rule_nfproto() {
+	[ -n "$1" ] || return 0
+	nfproto="meta nfproto { $(mklist "$1" ", ") }"
+}
+
+rule_oifname() {
+	[ -n "$1" ] || return 0
+	oifname="oifname { $(mklist "$1" ", " "\"") }"
+}
+
+rule_iifname() {
+	[ -n "$1" ] || return 0
+	iifname="iifname { $(mklist "$1" ", " "\"") }"
+}
+
+rule_zone() {
+	local device
+
+	[ -n "$2" ] || return 0
+
+	device="$(fw_zone_dev "$2")" || {
+		log warning "Rule '$name' contains an invalid $1 zone"
+		return 1
+	}
+
+	case "$1" in
+	src) rule_iifname "$device" ;;
+	dest) rule_oifname "$device" ;;
+	*)
+		log err "Invalid direction for zone function"
+		return 1
+		;;
+	esac
+}
+
+rule_port() {
+	local port port_negate rule xport
+
+	case "$1" in
+	src) xport="sport" ;;
+	dest) xport="dport" ;;
+	*)
+		log err "Invalid direction for port function"
+		return 1
+		;;
+	esac
+
+	[ -n "$2" ] || return 0
+
+	parse_rule_ports "$2" || {
+		log warning "Rule '$name' contains an invalid $1_port"
+		return 1
+	}
+	check_port_proto "$3" || {
+		log warning "Rules cannot combine a $1_port with protocols other than 'tcp' or 'udp'"
+		return 1
+	}
+
+	[ -n "$port" ] && rule="th $xport { $(mklist "$port" ", ") }"
+	[ -n "$port_negate" ] && rule="$rule th $xport != { $(mklist "$port_negate" ", ") }"
+
+	eval "$xport"='$rule'
+	return 0
+}
+
+rule_addr() {
+	local rule rule6 xaddr
+	local ipv4 ipv6 ipset
+	local ipv4_negate ipv6_negate ipset_negate
+
+	case "$1" in
+	src) xaddr="saddr" ;;
+	dest) xaddr="daddr" ;;
+	*)
+		log err "Invalid direction for addr function"
+		return 1
+		;;
+	esac
+
+	[ -n "$2" ] || return 0
+
+	if [ -n "$3" ] && ! check_family "$3"; then
+		log warning "Rule '$name' contains an invalid family"
+		return 1
+	fi
+	parse_rule_ips "$2" || {
+		log warning "Rule '$name' contains an invalid $1_ip"
+		return 1
+	}
+	if [ -n "$ipset$ipset_negate" ] && [ -n "$ipv4$ipv6$ipv4_negate$ipv6_negate" ]; then
+		log warning "Rules must not mix IP addresses and sets in the $1_ip option"
+		return 1
+	fi
+	if [ -n "$ipv4$ipv4_negate" ] && [ "$3" = "ipv6" ]; then
+		log warning "Rules cannot combine an ipv4 $1_ip with the 'ipv6' family option"
+		return 1
+	fi
+	if [ -n "$ipv6$ipv6_negate" ] && [ "$3" = "ipv4" ]; then
+		log warning "Rules cannot combine an ipv6 $1_ip with the 'ipv4' family option"
+		return 1
+	fi
+	if [ "$(echo "$ipset" | wc -w)" -gt 1 ] || [ "$(echo "$ipset_negate" | wc -w)" -gt 1 ]; then
+		log warning "Rules must not contain more than one set for the $1_ip option"
+		return 1
+	fi
+
+	[ -n "$ipv4" ] && rule="ip $xaddr { $(mklist "$ipv4" ", ") }"
+	[ -n "$ipv4_negate" ] && rule="$rule ip $xaddr != { $(mklist "$ipv4_negate" ", ") }"
+
+	[ -n "$ipv6" ] && rule6="ip6 $xaddr { $(mklist "$ipv6" ", ") }"
+	[ -n "$ipv6_negate" ] && rule6="$rule6 ip6 $xaddr != { $(mklist "$ipv6_negate" ", ") }"
+
+	[ -n "$ipset$ipset_negate" ] && case "$3" in
+	ipv4)
+		[ -n "$ipset" ] && rule="$rule ip $xaddr $ipset"
+		[ -n "$ipset_negate" ] && rule="$rule ip $xaddr != $ipset_negate"
+		;;
+	ipv6)
+		[ -n "$ipset" ] && rule6="$rule6 ip6 $xaddr $ipset"
+		[ -n "$ipset_negate" ] && rule6="$rule6 ip6 $xaddr != $ipset_negate"
+		;;
+	*)
+		log warning "Rules must contain the family option when a set is present in the $1_ip option"
+		return 1
+		;;
+	esac
+
+	eval "$xaddr"='$rule'
+	eval "$xaddr"6='$rule6'
+	return 0
+}
+
+rule_device() {
+	[ -n "$1" ] || return 0
+
+	[ -n "$2" ] || {
+		log warning "Rules must use the device and direction options in conjunction"
+		return 1
+	}
+
+	case "$2" in
+	in) rule_iifname "$1" ;;
+	out) rule_oifname "$1" ;;
+	*)
+		log warning "The direction rule option must contain either 'in' or 'out'"
+		return 1
+		;;
+	esac
+}
+
+rule_verdict() {
+	local class
+
+	[ -n "$1" ] || {
+		log warning "Rule is missing the DSCP class option"
+		return 1
+	}
+	class="$(check_class "$1")" || {
+		log warning "Rule '$name' contains an invalid DSCP class"
+		return 1
+	}
+
+	verdict="goto ct_set_$class"
+}
+
+create_user_rule() {
+	local enabled family proto direction device dest dest_ip dest_port src src_ip src_port counter class name
+	local nfproto l4proto oifname daddr daddr6 dport iifname saddr saddr6 sport verdict
+
+	config_get_bool enabled "$1" enabled 1
+	[ "$enabled" = 1 ] || return 0
+
+	config_get family "$1" family
+	config_get proto "$1" proto
+	config_get device "$1" device
+	config_get direction "$1" direction
+	config_get dest "$1" dest
+	config_get dest_ip "$1" dest_ip
+	config_get dest_port "$1" dest_port
+	config_get src "$1" src
+	config_get src_ip "$1" src_ip
+	config_get src_port "$1" src_port
+	config_get_bool counter "$1" counter
+	config_get class "$1" class
+	config_get name "$1" name
+
+	rule_nfproto "$family" || return 1
+	rule_l4proto "$proto" || return 1
+	rule_zone dest "$dest" || return 1
+	rule_addr dest "$dest_ip" "$family" || return 1
+	rule_port dest "$dest_port" "$proto" || return 1
+	rule_zone src "$src" || return 1
+	rule_addr src "$src_ip" "$family" || return 1
+	rule_port src "$src_port" "$proto" || return 1
+	rule_device "$device" "$direction" || return 1
+	rule_verdict "$class" || return 1
+
+	[ -z "$daddr$saddr$daddr6$saddr6" ] && {
+		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $dport $iifname $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+		return 0
+	}
+	[ -n "$daddr$saddr" ] && {
+		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $daddr $dport $iifname $saddr $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+	}
+	[ -n "$daddr6$saddr6" ] && {
+		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $daddr6 $dport $iifname $saddr6 $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+	}
+	return 0
+}
+
+create_client_hints_rule() {
+	local client_hints
+
+	config_get_bool client_hints global client_hints 1
+	[ "$client_hints" = 1 ] || return 0
+
+	post_include "insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != \$wan ip6 dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify static_classify ip dscp != { cs0, cs6, cs7 } iifname != \$wan ip dscp vmap @dscp_ct"
+}
+
+create_threaded_client_rule() {
+	local class_bulk threaded_client_min_bytes threaded_client_min_connections
+
+	config_get threaded_client_min_connections global threaded_client_min_connections 10
+	if ! check_uint "$threaded_client_min_connections" || [ "$threaded_client_min_connections" -lt 2 ]; then
+		log err "Global option 'threaded_client_min_connections' contains an invalid value"
+		return 1
+	fi
+	config_get threaded_client_min_bytes global threaded_client_min_bytes 10000
+	if ! check_uint "$threaded_client_min_bytes" || [ "$threaded_client_min_bytes" = 0 ]; then
+		log err "Global option 'threaded_client_min_bytes' contains an invalid value"
+		return 1
+	fi
+	config_get class_bulk global class_bulk le
+	class_bulk="$(check_class "$class_bulk")" || {
+		log err "Global option 'class_bulk' contains an invalid DSCP class"
+		return 1
+	}
+
+	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
+	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
+
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+}
+
+create_threaded_service_rule() {
+	local class_high_throughput threaded_service_min_bytes threaded_service_min_connections
+
+	config_get threaded_service_min_connections global threaded_service_min_connections 3
+	if ! check_uint "$threaded_service_min_connections" || [ "$threaded_service_min_connections" -lt 2 ]; then
+		log err "Global option 'threaded_service_min_connections' contains an invalid value"
+		return 1
+	fi
+	config_get threaded_service_min_bytes global threaded_service_min_bytes 1000000
+	check_uint "$threaded_service_min_bytes" || {
+		log err "Global option 'threaded_service_min_bytes' contains an invalid value"
+		return 1
+	}
+	config_get class_high_throughput global class_high_throughput af13
+	class_high_throughput="$(check_class "$class_high_throughput")" || {
+		log err "Global option 'class_high_throughput' contains an invalid DSCP class"
+		return 1
+	}
+
+	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
+	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
+
+	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service goto ct_set_$class_high_throughput"
+
+	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
+	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_$class_high_throughput"
+}
+
+create_dscp_mark_rule() {
+	local wmm
+
+	config_get_bool wmm global wmm 0
+	[ "$wmm" = 1 ] && {
+		post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark and \$ct_dscp vmap @ct_wmm"
+	}
+	post_include "add rule inet dscpclassify postrouting ct mark and \$ct_dscp vmap @ct_dscp"
+}
+
+create_pre_include() {
+	pre_include "define lan = { $(mklist "$lan" ", " "\"") }"
+	pre_include "define wan = { $(mklist "$wan" ", " "\"") }"
+
+	pre_include "add table inet dscpclassify"
+	check_set_exists threaded_clients || pre_include "add set inet dscpclassify threaded_clients { type ipv4_addr . inet_service . inet_proto; flags timeout; }"
+	check_set_exists threaded_clients6 || pre_include "add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }"
+	check_set_exists threaded_services || pre_include "add set inet dscpclassify threaded_services { type ipv4_addr . ipv4_addr . inet_service . inet_proto; flags timeout; }"
+	check_set_exists threaded_services6 || pre_include "add set inet dscpclassify threaded_services6 { type ipv6_addr . ipv6_addr . inet_service . inet_proto; flags timeout; }"
+
+	pre_include "include \"/etc/dscpclassify.d/verdicts.nft\""
+	pre_include "include \"/etc/dscpclassify.d/maps.nft\""
+}
+
+create_post_include() {
+	create_client_hints_rule || return 1
+
+	config_foreach create_user_set set   # depreciating in favour of 'ipset' section name for consistency with fw4
+	config_foreach create_user_set ipset # section name consistent with fw4
+	config_foreach_reverse create_user_rule rule
+
+	create_threaded_client_rule || return 1
+	create_threaded_service_rule || return 1
+
+	create_dscp_mark_rule || return 1
+}
+
+flush_table() {
+	for i in $(nft -j list chains | jsonfilter -e '@.nftables[@.chain.table="dscpclassify"].chain.name'); do
+		nft flush chain inet dscpclassify "$i"
+	done
+	for i in $(nft -j list maps | jsonfilter -e '@.nftables[@.map.table="dscpclassify"].map.name'); do
+		nft flush map inet dscpclassify "$i"
+	done
+}
+
+get_zones() {
+	local dev lan_zones wan_zones
+
+	config_get lan global lan_device
+	config_get lan_zones global lan_zone "lan"
+
+	for i in $lan_zones; do
+		dev="$(fw_zone_dev "$i")" && lan="${lan:+$lan }$dev"
+	done
+	[ -n "$lan" ] || return 1
+
+	config_get wan global wan_device
+	config_get wan_zones global wan_zone "wan"
+
+	for i in $wan_zones; do
+		dev="$(fw_zone_dev "$i")" && wan="${wan:+$wan }$dev"
+	done
+	[ -n "$wan" ] || return 1
+}
+
+setup() {
+	local action lan wan
+
+	delete_includes
+	action="$1"
+
+	config_load dscpclassify || return 1
+	config_get_bool DEBUG global debug "$DEBUG"
+
+	get_zones || return 0
+
+	[ "$action" = "start" ] && delete_table
+
+	create_path "/tmp/etc" || return 1
+	create_pre_include || return 1
+	create_post_include || return 1
+
+	[ "$action" = "reload" ] && flush_table
+
+	nft -f "/etc/dscpclassify.d/main.nft" || return 1
+	[ "$DEBUG" != 1 ] && delete_includes
+
+	return 0
+}
+
+start_service() {
+	setup start || {
+		log err "Service start failed"
+		[ "$DEBUG" != 1 ] && cleanup
+		return 1
+	}
+	log notice "Service started"
+}
+
+reload_service() {
+	/etc/init.d/dscpclassify status &>/dev/null || {
+		echo "The dscpclassify service does not appear to be loaded."
+		return 1
+	}
+
+	setup reload || {
+		log err "Service reload failed"
+		[ "$DEBUG" != 1 ] && cleanup
+		return 1
+	}
+	log notice "Service reloaded"
+}
+
+stop_service() {
+	cleanup
+	log notice "Service stopped"
+}

--- a/ruleset3.nft
+++ b/ruleset3.nft
@@ -1,0 +1,603 @@
+table inet fw4 {
+	ct helper amanda {
+		type "amanda" protocol udp
+		l3proto inet
+	}
+
+	ct helper ftp {
+		type "ftp" protocol tcp
+		l3proto inet
+	}
+
+	ct helper RAS {
+		type "RAS" protocol udp
+		l3proto inet
+	}
+
+	ct helper Q.931 {
+		type "Q.931" protocol tcp
+		l3proto inet
+	}
+
+	ct helper irc {
+		type "irc" protocol tcp
+		l3proto ip
+	}
+
+	ct helper pptp {
+		type "pptp" protocol tcp
+		l3proto ip
+	}
+
+	ct helper sip {
+		type "sip" protocol udp
+		l3proto inet
+	}
+
+	ct helper snmp {
+		type "snmp" protocol udp
+		l3proto ip
+	}
+
+	ct helper tftp {
+		type "tftp" protocol udp
+		l3proto inet
+	}
+
+	chain input {
+		type filter hook input priority filter; policy drop;
+		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
+		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		tcp flags syn / fin,syn,rst,ack jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump input_lan comment "!fw4: Handle lan IPv4 input traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } jump input_wan comment "!fw4: Handle wan IPv4 input traffic"
+		jump handle_reject
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy drop;
+		ct state established,related accept comment "!fw4: Allow forwarded established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump forward_lan comment "!fw4: Handle lan IPv4 forward traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } jump forward_wan comment "!fw4: Handle wan IPv4 forward traffic"
+		jump upnp_forward comment "Hook into miniupnpd forwarding chain"
+		jump handle_reject
+	}
+
+	chain output {
+		type filter hook output priority filter; policy drop;
+		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
+		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } jump output_lan comment "!fw4: Handle lan IPv4 output traffic"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } jump output_wan comment "!fw4: Handle wan IPv4 output traffic"
+		jump handle_reject
+	}
+
+	chain prerouting {
+		type filter hook prerouting priority filter; policy accept;
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump helper_lan comment "!fw4: Handle lan IPv4 helper assignment"
+	}
+
+	chain handle_reject {
+		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
+		reject comment "!fw4: Reject any other traffic"
+	}
+
+	chain syn_flood {
+		limit rate 25/second burst 50 packets return comment "!fw4: Accept SYN packets below rate-limit"
+		drop comment "!fw4: Drop excess packets"
+	}
+
+	chain input_lan {
+		jump accept_from_lan
+	}
+
+	chain output_lan {
+		jump accept_to_lan
+	}
+
+	chain forward_lan {
+		meta nfproto ipv4 jump accept_to_Net2Shield comment "!fw4: Accept lan to Net2Shield IPv4 forwarding"
+		meta nfproto ipv4 jump accept_to_wan comment "!fw4: Accept lan to wan IPv4 forwarding"
+		meta nfproto ipv4 jump accept_to_Proton1VPN comment "!fw4: Accept lan to Proton1VPN IPv4 forwarding"
+		jump accept_to_lan
+		log prefix "reject lan forward: "
+	}
+
+	chain helper_lan {
+		udp dport 10080 ct helper set "amanda" comment "!fw4: Amanda backup and archiving proto"
+		tcp dport 21 ct helper set "ftp" comment "!fw4: FTP passive connection tracking"
+		udp dport 1719 ct helper set "RAS" comment "!fw4: RAS proto tracking"
+		tcp dport 1720 ct helper set "Q.931" comment "!fw4: Q.931 proto tracking"
+		meta nfproto ipv4 tcp dport 6667 ct helper set "irc" comment "!fw4: IRC DCC connection tracking"
+		meta nfproto ipv4 tcp dport 1723 ct helper set "pptp" comment "!fw4: PPTP VPN connection tracking"
+		udp dport 5060 ct helper set "sip" comment "!fw4: SIP VoIP connection tracking"
+		meta nfproto ipv4 udp dport 161 ct helper set "snmp" comment "!fw4: SNMP monitoring connection tracking"
+		udp dport 69 ct helper set "tftp" comment "!fw4: TFTP connection tracking"
+	}
+
+	chain accept_from_lan {
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 18093 bytes 1425557 accept comment "!fw4: accept lan IPv4 traffic"
+	}
+
+	chain accept_to_lan {
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 10 bytes 3528 accept comment "!fw4: accept lan IPv4 traffic"
+	}
+
+	chain input_wan {
+		meta nfproto ipv4 udp dport 68 counter packets 0 bytes 0 accept comment "!fw4: Allow-DHCP-Renew"
+		icmp type echo-request counter packets 15308 bytes 695648 accept comment "!fw4: Allow-Ping"
+		meta nfproto ipv4 meta l4proto igmp counter packets 0 bytes 0 accept comment "!fw4: Allow-IGMP"
+		jump reject_from_wan
+	}
+
+	chain output_wan {
+		jump accept_to_wan
+	}
+
+	chain forward_wan {
+		meta nfproto ipv4 meta l4proto esp counter packets 0 bytes 0 jump accept_to_lan comment "!fw4: Allow-IPSec-ESP"
+		meta nfproto ipv4 udp dport 500 counter packets 0 bytes 0 jump accept_to_lan comment "!fw4: Allow-ISAKMP"
+		jump reject_to_wan
+		log prefix "reject wan forward: "
+	}
+
+	chain accept_to_wan {
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 18518 bytes 1621931 accept comment "!fw4: accept wan IPv4 traffic"
+	}
+
+	chain reject_from_wan {
+		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 3111 bytes 159533 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+	}
+
+	chain reject_to_wan {
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 0 bytes 0 log prefix "reject wan out: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+	}
+
+	chain input_Net2Shield {
+		jump reject_from_Net2Shield
+	}
+
+	chain output_Net2Shield {
+		jump accept_to_Net2Shield
+	}
+
+	chain forward_Net2Shield {
+		jump reject_to_Net2Shield
+		log prefix "reject Net2Shield forward: "
+	}
+
+	chain accept_to_Net2Shield {
+	}
+
+	chain reject_from_Net2Shield {
+	}
+
+	chain reject_to_Net2Shield {
+	}
+
+	chain input_Proton1VPN {
+		jump reject_from_Proton1VPN
+	}
+
+	chain output_Proton1VPN {
+		jump accept_to_Proton1VPN
+	}
+
+	chain forward_Proton1VPN {
+		jump reject_to_Proton1VPN
+		log prefix "reject Proton1VPN forward: "
+	}
+
+	chain accept_to_Proton1VPN {
+	}
+
+	chain reject_from_Proton1VPN {
+	}
+
+	chain reject_to_Proton1VPN {
+	}
+
+	chain dstnat {
+		type nat hook prerouting priority dstnat; policy accept;
+		jump upnp_prerouting comment "Hook into miniupnpd prerouting chain"
+	}
+
+	chain srcnat {
+		type nat hook postrouting priority srcnat; policy accept;
+		meta nfproto ipv4 oifname { "eth0", "eth5" } jump srcnat_wan comment "!fw4: Handle wan IPv4 srcnat traffic"
+		jump upnp_postrouting comment "Hook into miniupnpd postrouting chain"
+	}
+
+	chain srcnat_wan {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 wan traffic"
+	}
+
+	chain srcnat_Net2Shield {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 Net2Shield traffic"
+	}
+
+	chain srcnat_Proton1VPN {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 Proton1VPN traffic"
+	}
+
+	chain raw_prerouting {
+		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain raw_output {
+		type filter hook output priority raw; policy accept;
+	}
+
+	chain mangle_prerouting {
+		type filter hook prerouting priority mangle; policy accept;
+	}
+
+	chain mangle_postrouting {
+		type filter hook postrouting priority mangle; policy accept;
+	}
+
+	chain mangle_input {
+		type filter hook input priority mangle; policy accept;
+	}
+
+	chain mangle_output {
+		type route hook output priority mangle; policy accept;
+	}
+
+	chain mangle_forward {
+		type filter hook forward priority mangle; policy accept;
+		meta nfproto ipv4 iifname { "eth0", "eth5" } tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4 ingress MTU fixing"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4 egress MTU fixing"
+	}
+
+	chain upnp_forward {
+	}
+
+	chain upnp_prerouting {
+	}
+
+	chain upnp_postrouting {
+	}
+}
+table inet dscpclassify {
+	set threaded_clients {
+		type ipv4_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	set threaded_services {
+		type ipv4_addr . ipv4_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	map ct_dscp {
+		type mark : verdict
+		elements = { 0x00000000 : goto dscp_set_cs0, 0x00000001 : goto dscp_set_le, 0x00000008 : goto dscp_set_cs1, 0x0000000a : goto dscp_set_af11, 0x0000000c : goto dscp_set_af12,
+			     0x0000000e : goto dscp_set_af13, 0x00000010 : goto dscp_set_cs2, 0x00000012 : goto dscp_set_af21, 0x00000014 : goto dscp_set_af22, 0x00000016 : goto dscp_set_af23,
+			     0x00000018 : goto dscp_set_cs3, 0x0000001a : goto dscp_set_af31, 0x0000001c : goto dscp_set_af32, 0x0000001e : goto dscp_set_af33, 0x00000020 : goto dscp_set_cs4,
+			     0x00000022 : goto dscp_set_af41, 0x00000024 : goto dscp_set_af42, 0x00000026 : goto dscp_set_af43, 0x00000028 : goto dscp_set_cs5, 0x0000002c : goto dscp_set_va,
+			     0x0000002e : goto dscp_set_ef, 0x00000030 : goto dscp_set_cs6, 0x00000038 : goto dscp_set_cs7 }
+	}
+
+	map ct_wmm {
+		type mark : verdict
+		elements = { 0x00000000 : goto dscp_set_cs0, 0x00000001 : goto dscp_set_le, 0x00000008 : goto dscp_set_cs1, 0x0000000a : goto dscp_set_cs0, 0x0000000c : goto dscp_set_cs0,
+			     0x0000000e : goto dscp_set_cs0, 0x00000010 : goto dscp_set_cs0, 0x00000012 : goto dscp_set_cs3, 0x00000014 : goto dscp_set_cs3, 0x00000016 : goto dscp_set_cs3,
+			     0x00000018 : goto dscp_set_cs4, 0x0000001a : goto dscp_set_cs4, 0x0000001c : goto dscp_set_cs4, 0x0000001e : goto dscp_set_cs4, 0x00000020 : goto dscp_set_cs4,
+			     0x00000022 : goto dscp_set_cs4, 0x00000024 : goto dscp_set_cs4, 0x00000026 : goto dscp_set_cs4, 0x00000028 : goto dscp_set_cs5, 0x0000002c : goto dscp_set_cs6,
+			     0x0000002e : goto dscp_set_cs6, 0x00000030 : goto dscp_set_cs7, 0x00000038 : goto dscp_set_cs7 }
+	}
+
+	map dscp_ct {
+		type dscp : verdict
+		elements = { cs0 : goto ct_set_cs0,
+			     0x01 : goto ct_set_le,
+			     cs1 : goto ct_set_cs1,
+			     af11 : goto ct_set_af11,
+			     af12 : goto ct_set_af12,
+			     af13 : goto ct_set_af13,
+			     cs2 : goto ct_set_cs2,
+			     af21 : goto ct_set_af21,
+			     af22 : goto ct_set_af22,
+			     af23 : goto ct_set_af23,
+			     cs3 : goto ct_set_cs3,
+			     af31 : goto ct_set_af31,
+			     af32 : goto ct_set_af32,
+			     af33 : goto ct_set_af33,
+			     cs4 : goto ct_set_cs4,
+			     af41 : goto ct_set_af41,
+			     af42 : goto ct_set_af42,
+			     af43 : goto ct_set_af43,
+			     cs5 : goto ct_set_cs5,
+			     0x2c : goto ct_set_va,
+			     ef : goto ct_set_ef,
+			     cs6 : goto ct_set_cs6,
+			     cs7 : goto ct_set_cs7 }
+	}
+
+	chain dscp_set_cs0 {
+		ip dscp set cs0
+		ip6 dscp set cs0
+	}
+
+	chain dscp_set_le {
+		ip dscp set 0x01
+		ip6 dscp set 0x01
+	}
+
+	chain dscp_set_cs1 {
+		ip dscp set cs1
+		ip6 dscp set cs1
+	}
+
+	chain dscp_set_af11 {
+		ip dscp set af11
+		ip6 dscp set af11
+	}
+
+	chain dscp_set_af12 {
+		ip dscp set af12
+		ip6 dscp set af12
+	}
+
+	chain dscp_set_af13 {
+		ip dscp set af13
+		ip6 dscp set af13
+	}
+
+	chain dscp_set_cs2 {
+		ip dscp set cs2
+		ip6 dscp set cs2
+	}
+
+	chain dscp_set_af21 {
+		ip dscp set af21
+		ip6 dscp set af21
+	}
+
+	chain dscp_set_af22 {
+		ip dscp set af22
+		ip6 dscp set af22
+	}
+
+	chain dscp_set_af23 {
+		ip dscp set af23
+		ip6 dscp set af23
+	}
+
+	chain dscp_set_cs3 {
+		ip dscp set cs3
+		ip6 dscp set cs3
+	}
+
+	chain dscp_set_af31 {
+		ip dscp set af31
+		ip6 dscp set af31
+	}
+
+	chain dscp_set_af32 {
+		ip dscp set af32
+		ip6 dscp set af32
+	}
+
+	chain dscp_set_af33 {
+		ip dscp set af33
+		ip6 dscp set af33
+	}
+
+	chain dscp_set_cs4 {
+		ip dscp set cs4
+		ip6 dscp set cs4
+	}
+
+	chain dscp_set_af41 {
+		ip dscp set af41
+		ip6 dscp set af41
+	}
+
+	chain dscp_set_af42 {
+		ip dscp set af42
+		ip6 dscp set af42
+	}
+
+	chain dscp_set_af43 {
+		ip dscp set af43
+		ip6 dscp set af43
+	}
+
+	chain dscp_set_cs5 {
+		ip dscp set cs5
+		ip6 dscp set cs5
+	}
+
+	chain dscp_set_va {
+		ip dscp set 0x2c
+		ip6 dscp set 0x2c
+	}
+
+	chain dscp_set_ef {
+		ip dscp set ef
+		ip6 dscp set ef
+	}
+
+	chain dscp_set_cs6 {
+		ip dscp set cs6
+		ip6 dscp set cs6
+	}
+
+	chain dscp_set_cs7 {
+		ip dscp set cs7
+		ip6 dscp set cs7
+	}
+
+	chain ct_set_cs0 {
+		ct mark set ct mark & 0xffffff40 | 0x00000040
+	}
+
+	chain ct_set_le {
+		ct mark set ct mark & 0xffffff01 | 0x00000001
+	}
+
+	chain ct_set_cs1 {
+		ct mark set ct mark & 0xffffff08 | 0x00000008
+	}
+
+	chain ct_set_af11 {
+		ct mark set ct mark & 0xffffff0a | 0x0000000a
+	}
+
+	chain ct_set_af12 {
+		ct mark set ct mark & 0xffffff0c | 0x0000000c
+	}
+
+	chain ct_set_af13 {
+		ct mark set ct mark & 0xffffff0e | 0x0000000e
+	}
+
+	chain ct_set_cs2 {
+		ct mark set ct mark & 0xffffff10 | 0x00000010
+	}
+
+	chain ct_set_af21 {
+		ct mark set ct mark & 0xffffff12 | 0x00000012
+	}
+
+	chain ct_set_af22 {
+		ct mark set ct mark & 0xffffff14 | 0x00000014
+	}
+
+	chain ct_set_af23 {
+		ct mark set ct mark & 0xffffff16 | 0x00000016
+	}
+
+	chain ct_set_cs3 {
+		ct mark set ct mark & 0xffffff18 | 0x00000018
+	}
+
+	chain ct_set_af31 {
+		ct mark set ct mark & 0xffffff1a | 0x0000001a
+	}
+
+	chain ct_set_af32 {
+		ct mark set ct mark & 0xffffff1c | 0x0000001c
+	}
+
+	chain ct_set_af33 {
+		ct mark set ct mark & 0xffffff1e | 0x0000001e
+	}
+
+	chain ct_set_cs4 {
+		ct mark set ct mark & 0xffffff20 | 0x00000020
+	}
+
+	chain ct_set_af41 {
+		ct mark set ct mark & 0xffffff22 | 0x00000022
+	}
+
+	chain ct_set_af42 {
+		ct mark set ct mark & 0xffffff24 | 0x00000024
+	}
+
+	chain ct_set_af43 {
+		ct mark set ct mark & 0xffffff26 | 0x00000026
+	}
+
+	chain ct_set_cs5 {
+		ct mark set ct mark & 0xffffff28 | 0x00000028
+	}
+
+	chain ct_set_va {
+		ct mark set ct mark & 0xffffff2c | 0x0000002c
+	}
+
+	chain ct_set_ef {
+		ct mark set ct mark & 0xffffff2e | 0x0000002e
+	}
+
+	chain ct_set_cs6 {
+		ct mark set ct mark & 0xffffff30 | 0x00000030
+	}
+
+	chain ct_set_cs7 {
+		ct mark set ct mark & 0xffffff38 | 0x00000038
+	}
+
+	chain input {
+		type filter hook input priority filter + 2; policy accept;
+		iifname "lo" return
+		ct mark & 0x000000ff == 0x00000000 ct direction original jump static_classify
+		ct mark & 0x00000080 == 0x00000080 jump dynamic_classify
+	}
+
+	chain postrouting {
+		type filter hook postrouting priority filter + 2; policy accept;
+		oifname "lo" return
+		ct mark & 0x000000ff == 0x00000000 ct direction original jump static_classify
+		ct mark & 0x00000080 == 0x00000080 jump dynamic_classify
+		oifname { "br-lan", "br-swlan", "eth2" } ct mark & 0x0000003f vmap @ct_wmm
+		ct mark & 0x0000003f vmap @ct_dscp
+	}
+
+	chain static_classify {
+		ip daddr 88.82.11.0/24 udp sport 4500 udp dport 4500 counter packets 0 bytes 0 goto ct_set_ef comment "Vodafone UK WiFiCall ESP"
+		udp dport 3478 counter packets 0 bytes 0 goto ct_set_af41 comment "STUN various"
+		meta l4proto udp ip daddr 95.172.238.85 counter packets 0 bytes 0 goto ct_set_ef comment "Voipify VoIP"
+		meta l4proto icmp counter packets 13 bytes 756 goto ct_set_cs5 comment "ICMP"
+		ip daddr 17.0.0.0/8 th sport { 16384-16387, 16393-16402 } counter packets 0 bytes 0 goto ct_set_af41 comment "Apple FaceTime"
+		meta l4proto udp ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 } counter packets 0 bytes 0 goto ct_set_ef comment "Discord VoIP"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50040-50059 counter packets 0 bytes 0 goto ct_set_af21 comment "Microsoft Teams sharing"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50020-50039 counter packets 0 bytes 0 goto ct_set_af41 comment "Microsoft Teams video"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50000-50019 counter packets 0 bytes 0 goto ct_set_ef comment "Microsoft Teams voice"
+		tcp dport 22 counter packets 0 bytes 0 goto ct_set_cs2 comment "SSH"
+		udp dport 123 counter packets 0 bytes 0 goto ct_set_cs5 comment "NTP"
+		udp dport { 67, 68 } counter packets 0 bytes 0 goto ct_set_cs5 comment "BOOTP/DHCP"
+		meta l4proto { tcp, udp } ip daddr { 1.0.0.1, 1.1.1.1, 8.8.4.4, 8.8.8.8, 9.9.9.9, 9.9.9.11, 94.140.14.0/24, 149.112.112.11, 149.112.112.112 } th dport 443 counter packets 0 bytes 0 goto ct_set_cs5 comment "DoH"
+		meta l4proto { tcp, udp } th dport { 53, 853, 5353 } counter packets 7 bytes 526 goto ct_set_cs5 comment "DNS"
+		ip dscp != { cs0, cs6, cs7 } iifname != { "eth0", "eth5" } (@nh,8,8 & 0xfc) >> 2 vmap @dscp_ct
+		meta l4proto != { tcp, udp } goto ct_set_cs0
+		ct mark set ct mark & 0xffffff80 | 0x00000080
+	}
+
+	chain dynamic_classify {
+		ct status & seen-reply != seen-reply return
+		ct direction reply goto dynamic_classify_reply
+		ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
+		ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
+	}
+
+	chain dynamic_classify_reply {
+		ct reply packets 1 jump established_connection
+		ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
+		ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
+	}
+
+	chain established_connection {
+		meter tc_detect size 65535 { ip daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+		meter ts_detect size 65535 { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 30s }
+	}
+
+	chain threaded_client {
+		meter tc_orig_bulk size 65535 { ip saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+	}
+
+	chain threaded_client_reply {
+		meter tc_reply_bulk size 65535 { ip daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+	}
+
+	chain threaded_service {
+		ct original bytes < 1000000 return
+		update @threaded_services { ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto timeout 5m }
+		goto ct_set_af13
+	}
+
+	chain threaded_service_reply {
+		ct reply bytes < 1000000 return
+		update @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5m }
+		goto ct_set_af13
+	}
+}

--- a/ruleset3.nft
+++ b/ruleset3.nft
@@ -119,16 +119,16 @@ table inet fw4 {
 	}
 
 	chain accept_from_lan {
-		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 18093 bytes 1425557 accept comment "!fw4: accept lan IPv4 traffic"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 105611 bytes 8473398 accept comment "!fw4: accept lan IPv4 traffic"
 	}
 
 	chain accept_to_lan {
-		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 10 bytes 3528 accept comment "!fw4: accept lan IPv4 traffic"
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 159 bytes 53625 accept comment "!fw4: accept lan IPv4 traffic"
 	}
 
 	chain input_wan {
-		meta nfproto ipv4 udp dport 68 counter packets 0 bytes 0 accept comment "!fw4: Allow-DHCP-Renew"
-		icmp type echo-request counter packets 15308 bytes 695648 accept comment "!fw4: Allow-Ping"
+		meta nfproto ipv4 udp dport 68 counter packets 1 bytes 28 accept comment "!fw4: Allow-DHCP-Renew"
+		icmp type echo-request counter packets 68291 bytes 2960312 accept comment "!fw4: Allow-Ping"
 		meta nfproto ipv4 meta l4proto igmp counter packets 0 bytes 0 accept comment "!fw4: Allow-IGMP"
 		jump reject_from_wan
 	}
@@ -145,11 +145,11 @@ table inet fw4 {
 	}
 
 	chain accept_to_wan {
-		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 18518 bytes 1621931 accept comment "!fw4: accept wan IPv4 traffic"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 114619 bytes 10455016 accept comment "!fw4: accept wan IPv4 traffic"
 	}
 
 	chain reject_from_wan {
-		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 3111 bytes 159533 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 15981 bytes 861785 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
 	}
 
 	chain reject_to_wan {
@@ -269,8 +269,20 @@ table inet dscpclassify {
 		flags dynamic,timeout
 	}
 
+	set threaded_clients6 {
+		type ipv6_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
 	set threaded_services {
 		type ipv4_addr . ipv4_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	set threaded_services6 {
+		type ipv6_addr . ipv6_addr . inet_service . inet_proto
 		size 65535
 		flags dynamic,timeout
 	}
@@ -318,6 +330,20 @@ table inet dscpclassify {
 			     ef : goto ct_set_ef,
 			     cs6 : goto ct_set_cs6,
 			     cs7 : goto ct_set_cs7 }
+	}
+
+	set xcloud {
+		type ipv4_addr
+		flags interval
+		auto-merge
+		elements = { 13.104.0.0/14 }
+	}
+
+	set GeForceNOWIPv4 {
+		type ipv4_addr
+		flags interval
+		auto-merge
+		elements = { 80.84.160.0/20 }
 	}
 
 	chain dscp_set_cs0 {
@@ -544,21 +570,25 @@ table inet dscpclassify {
 	}
 
 	chain static_classify {
-		ip daddr 88.82.11.0/24 udp sport 4500 udp dport 4500 counter packets 0 bytes 0 goto ct_set_ef comment "Vodafone UK WiFiCall ESP"
-		udp dport 3478 counter packets 0 bytes 0 goto ct_set_af41 comment "STUN various"
-		meta l4proto udp ip daddr 95.172.238.85 counter packets 0 bytes 0 goto ct_set_ef comment "Voipify VoIP"
-		meta l4proto icmp counter packets 13 bytes 756 goto ct_set_cs5 comment "ICMP"
-		ip daddr 17.0.0.0/8 th sport { 16384-16387, 16393-16402 } counter packets 0 bytes 0 goto ct_set_af41 comment "Apple FaceTime"
-		meta l4proto udp ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 } counter packets 0 bytes 0 goto ct_set_ef comment "Discord VoIP"
-		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50040-50059 counter packets 0 bytes 0 goto ct_set_af21 comment "Microsoft Teams sharing"
-		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50020-50039 counter packets 0 bytes 0 goto ct_set_af41 comment "Microsoft Teams video"
-		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50000-50019 counter packets 0 bytes 0 goto ct_set_ef comment "Microsoft Teams voice"
-		tcp dport 22 counter packets 0 bytes 0 goto ct_set_cs2 comment "SSH"
-		udp dport 123 counter packets 0 bytes 0 goto ct_set_cs5 comment "NTP"
-		udp dport { 67, 68 } counter packets 0 bytes 0 goto ct_set_cs5 comment "BOOTP/DHCP"
+		meta l4proto { tcp, udp } th dport { 53, 853, 5353 } counter packets 0 bytes 0 goto ct_set_cs5 comment "DNS"
 		meta l4proto { tcp, udp } ip daddr { 1.0.0.1, 1.1.1.1, 8.8.4.4, 8.8.8.8, 9.9.9.9, 9.9.9.11, 94.140.14.0/24, 149.112.112.11, 149.112.112.112 } th dport 443 counter packets 0 bytes 0 goto ct_set_cs5 comment "DoH"
-		meta l4proto { tcp, udp } th dport { 53, 853, 5353 } counter packets 7 bytes 526 goto ct_set_cs5 comment "DNS"
+		udp dport { 67, 68 } counter packets 0 bytes 0 goto ct_set_cs5 comment "BOOTP/DHCP"
+		udp dport 123 counter packets 0 bytes 0 goto ct_set_cs5 comment "NTP"
+		tcp dport 22 counter packets 0 bytes 0 goto ct_set_cs2 comment "SSH"
+		ip daddr @xcloud udp dport { 1000-1150, 9002 } counter packets 0 bytes 0 goto ct_set_af41 comment "Xbox Cloud Gaming"
+		ip daddr @GeForceNOWIPv4 udp sport 49003-49006 counter packets 0 bytes 0 goto ct_set_af41 comment "NVIDIA GFN"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50000-50019 counter packets 0 bytes 0 goto ct_set_ef comment "Microsoft Teams voice"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50020-50039 counter packets 0 bytes 0 goto ct_set_af41 comment "Microsoft Teams video"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50040-50059 counter packets 0 bytes 0 goto ct_set_af21 comment "Microsoft Teams sharing"
+		meta l4proto udp ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 } counter packets 0 bytes 0 goto ct_set_ef comment "Discord VoIP"
+		ip daddr 17.0.0.0/8 th sport { 16384-16387, 16393-16402 } counter packets 0 bytes 0 goto ct_set_af41 comment "Apple FaceTime"
+		meta l4proto icmp counter packets 6 bytes 504 goto ct_set_cs5 comment "ICMP"
+		udp dport != { 80, 443 } ip saddr 192.168.1.100 counter packets 0 bytes 0 goto ct_set_cs4 comment "Game Console non-HTTP"
+		meta l4proto udp ip daddr 95.172.238.85 counter packets 0 bytes 0 goto ct_set_ef comment "Voipify VoIP"
+		udp dport 3478 counter packets 0 bytes 0 goto ct_set_af41 comment "STUN various"
+		ip daddr 88.82.11.0/24 udp sport 4500 udp dport 4500 counter packets 0 bytes 0 goto ct_set_ef comment "Vodafone UK WiFiCall ESP"
 		ip dscp != { cs0, cs6, cs7 } iifname != { "eth0", "eth5" } (@nh,8,8 & 0xfc) >> 2 vmap @dscp_ct
+		ip6 dscp != { cs0, cs6, cs7 } iifname != { "eth0", "eth5" } (@nh,0,16 & 0xfc0) >> 6 vmap @dscp_ct
 		meta l4proto != { tcp, udp } goto ct_set_cs0
 		ct mark set ct mark & 0xffffff80 | 0x00000080
 	}
@@ -567,37 +597,47 @@ table inet dscpclassify {
 		ct status & seen-reply != seen-reply return
 		ct direction reply goto dynamic_classify_reply
 		ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
+		ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client
 		ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
+		ip6 saddr . ip6 daddr & ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
 	}
 
 	chain dynamic_classify_reply {
 		ct reply packets 1 jump established_connection
 		ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
+		ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply
 		ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
+		ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
 	}
 
 	chain established_connection {
 		meter tc_detect size 65535 { ip daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+		meter tc_detect6 size 65535 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }
 		meter ts_detect size 65535 { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 30s }
+		meter ts_detect6 size 65535 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
 	}
 
 	chain threaded_client {
 		meter tc_orig_bulk size 65535 { ip saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+		meter tc_orig_bulk6 size 65535 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
 	}
 
 	chain threaded_client_reply {
 		meter tc_reply_bulk size 65535 { ip daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+		meter tc_reply_bulk6 size 65535 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
 	}
 
 	chain threaded_service {
 		ct original bytes < 1000000 return
 		update @threaded_services { ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto timeout 5m }
+		update @threaded_services6 { ip6 saddr . ip6 daddr & ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }
 		goto ct_set_af13
 	}
 
 	chain threaded_service_reply {
 		ct reply bytes < 1000000 return
 		update @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5m }
+		update @threaded_services6 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }
 		goto ct_set_af13
 	}
 }

--- a/ruleset4.nft
+++ b/ruleset4.nft
@@ -119,7 +119,7 @@ table inet fw4 {
 	}
 
 	chain accept_from_lan {
-		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 74735 bytes 5956001 accept comment "!fw4: accept lan IPv4 traffic"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 76160 bytes 6066055 accept comment "!fw4: accept lan IPv4 traffic"
 	}
 
 	chain accept_to_lan {
@@ -128,7 +128,7 @@ table inet fw4 {
 
 	chain input_wan {
 		meta nfproto ipv4 udp dport 68 counter packets 1 bytes 28 accept comment "!fw4: Allow-DHCP-Renew"
-		icmp type echo-request counter packets 47616 bytes 2044770 accept comment "!fw4: Allow-Ping"
+		icmp type echo-request counter packets 48068 bytes 2065218 accept comment "!fw4: Allow-Ping"
 		meta nfproto ipv4 meta l4proto igmp counter packets 0 bytes 0 accept comment "!fw4: Allow-IGMP"
 		jump reject_from_wan
 	}
@@ -145,11 +145,11 @@ table inet fw4 {
 	}
 
 	chain accept_to_wan {
-		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 82446 bytes 7806144 accept comment "!fw4: accept wan IPv4 traffic"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 84059 bytes 7935770 accept comment "!fw4: accept wan IPv4 traffic"
 	}
 
 	chain reject_from_wan {
-		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 11807 bytes 636751 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 11966 bytes 649666 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
 	}
 
 	chain reject_to_wan {
@@ -260,5 +260,384 @@ table inet fw4 {
 	}
 
 	chain upnp_postrouting {
+	}
+}
+table inet dscpclassify {
+	set threaded_clients {
+		type ipv4_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	set threaded_clients6 {
+		type ipv6_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	set threaded_services {
+		type ipv4_addr . ipv4_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	set threaded_services6 {
+		type ipv6_addr . ipv6_addr . inet_service . inet_proto
+		size 65535
+		flags dynamic,timeout
+	}
+
+	map ct_dscp {
+		type mark : verdict
+		elements = { 0x00000000 : goto dscp_set_cs0, 0x00000001 : goto dscp_set_le, 0x00000008 : goto dscp_set_cs1, 0x0000000a : goto dscp_set_af11, 0x0000000c : goto dscp_set_af12,
+			     0x0000000e : goto dscp_set_af13, 0x00000010 : goto dscp_set_cs2, 0x00000012 : goto dscp_set_af21, 0x00000014 : goto dscp_set_af22, 0x00000016 : goto dscp_set_af23,
+			     0x00000018 : goto dscp_set_cs3, 0x0000001a : goto dscp_set_af31, 0x0000001c : goto dscp_set_af32, 0x0000001e : goto dscp_set_af33, 0x00000020 : goto dscp_set_cs4,
+			     0x00000022 : goto dscp_set_af41, 0x00000024 : goto dscp_set_af42, 0x00000026 : goto dscp_set_af43, 0x00000028 : goto dscp_set_cs5, 0x0000002c : goto dscp_set_va,
+			     0x0000002e : goto dscp_set_ef, 0x00000030 : goto dscp_set_cs6, 0x00000038 : goto dscp_set_cs7 }
+	}
+
+	map ct_wmm {
+		type mark : verdict
+		elements = { 0x00000000 : goto dscp_set_cs0, 0x00000001 : goto dscp_set_le, 0x00000008 : goto dscp_set_cs1, 0x0000000a : goto dscp_set_cs0, 0x0000000c : goto dscp_set_cs0,
+			     0x0000000e : goto dscp_set_cs0, 0x00000010 : goto dscp_set_cs0, 0x00000012 : goto dscp_set_cs3, 0x00000014 : goto dscp_set_cs3, 0x00000016 : goto dscp_set_cs3,
+			     0x00000018 : goto dscp_set_cs4, 0x0000001a : goto dscp_set_cs4, 0x0000001c : goto dscp_set_cs4, 0x0000001e : goto dscp_set_cs4, 0x00000020 : goto dscp_set_cs4,
+			     0x00000022 : goto dscp_set_cs4, 0x00000024 : goto dscp_set_cs4, 0x00000026 : goto dscp_set_cs4, 0x00000028 : goto dscp_set_cs5, 0x0000002c : goto dscp_set_cs6,
+			     0x0000002e : goto dscp_set_cs6, 0x00000030 : goto dscp_set_cs7, 0x00000038 : goto dscp_set_cs7 }
+	}
+
+	map dscp_ct {
+		type dscp : verdict
+		elements = { cs0 : goto ct_set_cs0,
+			     0x01 : goto ct_set_le,
+			     cs1 : goto ct_set_cs1,
+			     af11 : goto ct_set_af11,
+			     af12 : goto ct_set_af12,
+			     af13 : goto ct_set_af13,
+			     cs2 : goto ct_set_cs2,
+			     af21 : goto ct_set_af21,
+			     af22 : goto ct_set_af22,
+			     af23 : goto ct_set_af23,
+			     cs3 : goto ct_set_cs3,
+			     af31 : goto ct_set_af31,
+			     af32 : goto ct_set_af32,
+			     af33 : goto ct_set_af33,
+			     cs4 : goto ct_set_cs4,
+			     af41 : goto ct_set_af41,
+			     af42 : goto ct_set_af42,
+			     af43 : goto ct_set_af43,
+			     cs5 : goto ct_set_cs5,
+			     0x2c : goto ct_set_va,
+			     ef : goto ct_set_ef,
+			     cs6 : goto ct_set_cs6,
+			     cs7 : goto ct_set_cs7 }
+	}
+
+	set xcloud {
+		type ipv4_addr
+		flags interval
+		auto-merge
+		elements = { 13.104.0.0/14 }
+	}
+
+	set GeForceNOWIPv4 {
+		type ipv4_addr
+		flags interval
+		auto-merge
+		elements = { 80.84.160.0/20 }
+	}
+
+	chain dscp_set_cs0 {
+		ip dscp set cs0
+		ip6 dscp set cs0
+	}
+
+	chain dscp_set_le {
+		ip dscp set 0x01
+		ip6 dscp set 0x01
+	}
+
+	chain dscp_set_cs1 {
+		ip dscp set cs1
+		ip6 dscp set cs1
+	}
+
+	chain dscp_set_af11 {
+		ip dscp set af11
+		ip6 dscp set af11
+	}
+
+	chain dscp_set_af12 {
+		ip dscp set af12
+		ip6 dscp set af12
+	}
+
+	chain dscp_set_af13 {
+		ip dscp set af13
+		ip6 dscp set af13
+	}
+
+	chain dscp_set_cs2 {
+		ip dscp set cs2
+		ip6 dscp set cs2
+	}
+
+	chain dscp_set_af21 {
+		ip dscp set af21
+		ip6 dscp set af21
+	}
+
+	chain dscp_set_af22 {
+		ip dscp set af22
+		ip6 dscp set af22
+	}
+
+	chain dscp_set_af23 {
+		ip dscp set af23
+		ip6 dscp set af23
+	}
+
+	chain dscp_set_cs3 {
+		ip dscp set cs3
+		ip6 dscp set cs3
+	}
+
+	chain dscp_set_af31 {
+		ip dscp set af31
+		ip6 dscp set af31
+	}
+
+	chain dscp_set_af32 {
+		ip dscp set af32
+		ip6 dscp set af32
+	}
+
+	chain dscp_set_af33 {
+		ip dscp set af33
+		ip6 dscp set af33
+	}
+
+	chain dscp_set_cs4 {
+		ip dscp set cs4
+		ip6 dscp set cs4
+	}
+
+	chain dscp_set_af41 {
+		ip dscp set af41
+		ip6 dscp set af41
+	}
+
+	chain dscp_set_af42 {
+		ip dscp set af42
+		ip6 dscp set af42
+	}
+
+	chain dscp_set_af43 {
+		ip dscp set af43
+		ip6 dscp set af43
+	}
+
+	chain dscp_set_cs5 {
+		ip dscp set cs5
+		ip6 dscp set cs5
+	}
+
+	chain dscp_set_va {
+		ip dscp set 0x2c
+		ip6 dscp set 0x2c
+	}
+
+	chain dscp_set_ef {
+		ip dscp set ef
+		ip6 dscp set ef
+	}
+
+	chain dscp_set_cs6 {
+		ip dscp set cs6
+		ip6 dscp set cs6
+	}
+
+	chain dscp_set_cs7 {
+		ip dscp set cs7
+		ip6 dscp set cs7
+	}
+
+	chain ct_set_cs0 {
+		ct mark set ct mark & 0xffffff40 | 0x00000040
+	}
+
+	chain ct_set_le {
+		ct mark set ct mark & 0xffffff01 | 0x00000001
+	}
+
+	chain ct_set_cs1 {
+		ct mark set ct mark & 0xffffff08 | 0x00000008
+	}
+
+	chain ct_set_af11 {
+		ct mark set ct mark & 0xffffff0a | 0x0000000a
+	}
+
+	chain ct_set_af12 {
+		ct mark set ct mark & 0xffffff0c | 0x0000000c
+	}
+
+	chain ct_set_af13 {
+		ct mark set ct mark & 0xffffff0e | 0x0000000e
+	}
+
+	chain ct_set_cs2 {
+		ct mark set ct mark & 0xffffff10 | 0x00000010
+	}
+
+	chain ct_set_af21 {
+		ct mark set ct mark & 0xffffff12 | 0x00000012
+	}
+
+	chain ct_set_af22 {
+		ct mark set ct mark & 0xffffff14 | 0x00000014
+	}
+
+	chain ct_set_af23 {
+		ct mark set ct mark & 0xffffff16 | 0x00000016
+	}
+
+	chain ct_set_cs3 {
+		ct mark set ct mark & 0xffffff18 | 0x00000018
+	}
+
+	chain ct_set_af31 {
+		ct mark set ct mark & 0xffffff1a | 0x0000001a
+	}
+
+	chain ct_set_af32 {
+		ct mark set ct mark & 0xffffff1c | 0x0000001c
+	}
+
+	chain ct_set_af33 {
+		ct mark set ct mark & 0xffffff1e | 0x0000001e
+	}
+
+	chain ct_set_cs4 {
+		ct mark set ct mark & 0xffffff20 | 0x00000020
+	}
+
+	chain ct_set_af41 {
+		ct mark set ct mark & 0xffffff22 | 0x00000022
+	}
+
+	chain ct_set_af42 {
+		ct mark set ct mark & 0xffffff24 | 0x00000024
+	}
+
+	chain ct_set_af43 {
+		ct mark set ct mark & 0xffffff26 | 0x00000026
+	}
+
+	chain ct_set_cs5 {
+		ct mark set ct mark & 0xffffff28 | 0x00000028
+	}
+
+	chain ct_set_va {
+		ct mark set ct mark & 0xffffff2c | 0x0000002c
+	}
+
+	chain ct_set_ef {
+		ct mark set ct mark & 0xffffff2e | 0x0000002e
+	}
+
+	chain ct_set_cs6 {
+		ct mark set ct mark & 0xffffff30 | 0x00000030
+	}
+
+	chain ct_set_cs7 {
+		ct mark set ct mark & 0xffffff38 | 0x00000038
+	}
+
+	chain input {
+		type filter hook input priority filter + 2; policy accept;
+		iifname "lo" return
+		ct mark & 0x000000ff == 0x00000000 ct direction original jump static_classify
+		ct mark & 0x00000080 == 0x00000080 jump dynamic_classify
+	}
+
+	chain postrouting {
+		type filter hook postrouting priority filter + 2; policy accept;
+		oifname "lo" return
+		ct mark & 0x000000ff == 0x00000000 ct direction original jump static_classify
+		ct mark & 0x00000080 == 0x00000080 jump dynamic_classify
+		oifname { "br-lan", "br-swlan", "eth2" } ct mark & 0x0000003f vmap @ct_wmm
+		ct mark & 0x0000003f vmap @ct_dscp
+	}
+
+	chain static_classify {
+		meta l4proto { tcp, udp } th dport { 53, 853, 5353 } counter packets 0 bytes 0 goto ct_set_cs5 comment "DNS"
+		meta l4proto { tcp, udp } ip daddr { 1.0.0.1, 1.1.1.1, 8.8.4.4, 8.8.8.8, 9.9.9.9, 9.9.9.11, 94.140.14.0/24, 149.112.112.11, 149.112.112.112 } th dport 443 counter packets 0 bytes 0 goto ct_set_cs5 comment "DoH"
+		udp dport { 67, 68 } counter packets 0 bytes 0 goto ct_set_cs5 comment "BOOTP/DHCP"
+		udp dport 123 counter packets 0 bytes 0 goto ct_set_cs5 comment "NTP"
+		tcp dport 22 counter packets 0 bytes 0 goto ct_set_cs2 comment "SSH"
+		ip daddr @xcloud udp dport { 1000-1150, 9002 } counter packets 0 bytes 0 goto ct_set_af41 comment "Xbox Cloud Gaming"
+		ip daddr @GeForceNOWIPv4 udp sport 49003-49006 counter packets 0 bytes 0 goto ct_set_af41 comment "NVIDIA GFN"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50000-50019 counter packets 0 bytes 0 goto ct_set_ef comment "Microsoft Teams voice"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50020-50039 counter packets 0 bytes 0 goto ct_set_af41 comment "Microsoft Teams video"
+		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50040-50059 counter packets 0 bytes 0 goto ct_set_af21 comment "Microsoft Teams sharing"
+		meta l4proto udp ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 } counter packets 0 bytes 0 goto ct_set_ef comment "Discord VoIP"
+		ip daddr 17.0.0.0/8 th sport { 16384-16387, 16393-16402 } counter packets 0 bytes 0 goto ct_set_af41 comment "Apple FaceTime"
+		meta l4proto icmp counter packets 0 bytes 0 goto ct_set_cs5 comment "ICMP"
+		udp dport != { 80, 443 } ip saddr 192.168.1.100 counter packets 0 bytes 0 goto ct_set_cs4 comment "Game Console non-HTTP"
+		meta l4proto udp ip daddr 95.172.238.85 counter packets 0 bytes 0 goto ct_set_ef comment "Voipify VoIP"
+		udp dport 3478 counter packets 0 bytes 0 goto ct_set_af41 comment "STUN various"
+		ip daddr 88.82.11.0/24 udp sport 4500 udp dport 4500 counter packets 0 bytes 0 goto ct_set_ef comment "Vodafone UK WiFiCall ESP"
+		ip dscp != { cs0, cs6, cs7 } iifname != { "eth0", "eth5" } (@nh,8,8 & 0xfc) >> 2 vmap @dscp_ct
+		ip6 dscp != { cs0, cs6, cs7 } iifname != { "eth0", "eth5" } (@nh,0,16 & 0xfc0) >> 6 vmap @dscp_ct
+		meta l4proto != { tcp, udp } goto ct_set_cs0
+		ct mark set ct mark & 0xffffff80 | 0x00000080
+	}
+
+	chain dynamic_classify {
+		ct status & seen-reply != seen-reply return
+		ct direction reply goto dynamic_classify_reply
+		ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
+		ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client
+		ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
+		ip6 saddr . ip6 daddr & ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
+	}
+
+	chain dynamic_classify_reply {
+		ct reply packets 1 jump established_connection
+		ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
+		ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply
+		ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
+		ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
+	}
+
+	chain established_connection {
+		meter tc_detect size 65535 { ip daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }
+		meter tc_detect6 size 65535 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over 9/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }
+		meter ts_detect size 65535 { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 30s }
+		meter ts_detect6 size 65535 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over 2/minute } add @threaded_services6 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }
+	}
+
+	chain threaded_client {
+		meter tc_orig_bulk size 65535 { ip saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+		meter tc_orig_bulk6 size 65535 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_le
+	}
+
+	chain threaded_client_reply {
+		meter tc_reply_bulk size 65535 { ip daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+		meter tc_reply_bulk6 size 65535 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over 9999 bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_le
+	}
+
+	chain threaded_service {
+		ct original bytes < 1000000 return
+		update @threaded_services { ip saddr . ip daddr & 255.255.255.0 . th dport . meta l4proto timeout 5m }
+		update @threaded_services6 { ip6 saddr . ip6 daddr & ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }
+		goto ct_set_af13
+	}
+
+	chain threaded_service_reply {
+		ct reply bytes < 1000000 return
+		update @threaded_services { ip daddr . ip saddr & 255.255.255.0 . th sport . meta l4proto timeout 5m }
+		update @threaded_services6 { ip6 daddr . ip6 saddr & ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }
+		goto ct_set_af13
 	}
 }

--- a/ruleset4.nft
+++ b/ruleset4.nft
@@ -1,0 +1,264 @@
+table inet fw4 {
+	ct helper amanda {
+		type "amanda" protocol udp
+		l3proto inet
+	}
+
+	ct helper ftp {
+		type "ftp" protocol tcp
+		l3proto inet
+	}
+
+	ct helper RAS {
+		type "RAS" protocol udp
+		l3proto inet
+	}
+
+	ct helper Q.931 {
+		type "Q.931" protocol tcp
+		l3proto inet
+	}
+
+	ct helper irc {
+		type "irc" protocol tcp
+		l3proto ip
+	}
+
+	ct helper pptp {
+		type "pptp" protocol tcp
+		l3proto ip
+	}
+
+	ct helper sip {
+		type "sip" protocol udp
+		l3proto inet
+	}
+
+	ct helper snmp {
+		type "snmp" protocol udp
+		l3proto ip
+	}
+
+	ct helper tftp {
+		type "tftp" protocol udp
+		l3proto inet
+	}
+
+	chain input {
+		type filter hook input priority filter; policy drop;
+		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
+		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		tcp flags syn / fin,syn,rst,ack jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump input_lan comment "!fw4: Handle lan IPv4 input traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } jump input_wan comment "!fw4: Handle wan IPv4 input traffic"
+		jump handle_reject
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy drop;
+		ct state established,related accept comment "!fw4: Allow forwarded established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump forward_lan comment "!fw4: Handle lan IPv4 forward traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } jump forward_wan comment "!fw4: Handle wan IPv4 forward traffic"
+		jump upnp_forward comment "Hook into miniupnpd forwarding chain"
+		jump handle_reject
+	}
+
+	chain output {
+		type filter hook output priority filter; policy drop;
+		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
+		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
+		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } jump output_lan comment "!fw4: Handle lan IPv4 output traffic"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } jump output_wan comment "!fw4: Handle wan IPv4 output traffic"
+		jump handle_reject
+	}
+
+	chain prerouting {
+		type filter hook prerouting priority filter; policy accept;
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } jump helper_lan comment "!fw4: Handle lan IPv4 helper assignment"
+	}
+
+	chain handle_reject {
+		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
+		reject comment "!fw4: Reject any other traffic"
+	}
+
+	chain syn_flood {
+		limit rate 25/second burst 50 packets return comment "!fw4: Accept SYN packets below rate-limit"
+		drop comment "!fw4: Drop excess packets"
+	}
+
+	chain input_lan {
+		jump accept_from_lan
+	}
+
+	chain output_lan {
+		jump accept_to_lan
+	}
+
+	chain forward_lan {
+		meta nfproto ipv4 jump accept_to_Net2Shield comment "!fw4: Accept lan to Net2Shield IPv4 forwarding"
+		meta nfproto ipv4 jump accept_to_wan comment "!fw4: Accept lan to wan IPv4 forwarding"
+		meta nfproto ipv4 jump accept_to_Proton1VPN comment "!fw4: Accept lan to Proton1VPN IPv4 forwarding"
+		jump accept_to_lan
+		log prefix "reject lan forward: "
+	}
+
+	chain helper_lan {
+		udp dport 10080 ct helper set "amanda" comment "!fw4: Amanda backup and archiving proto"
+		tcp dport 21 ct helper set "ftp" comment "!fw4: FTP passive connection tracking"
+		udp dport 1719 ct helper set "RAS" comment "!fw4: RAS proto tracking"
+		tcp dport 1720 ct helper set "Q.931" comment "!fw4: Q.931 proto tracking"
+		meta nfproto ipv4 tcp dport 6667 ct helper set "irc" comment "!fw4: IRC DCC connection tracking"
+		meta nfproto ipv4 tcp dport 1723 ct helper set "pptp" comment "!fw4: PPTP VPN connection tracking"
+		udp dport 5060 ct helper set "sip" comment "!fw4: SIP VoIP connection tracking"
+		meta nfproto ipv4 udp dport 161 ct helper set "snmp" comment "!fw4: SNMP monitoring connection tracking"
+		udp dport 69 ct helper set "tftp" comment "!fw4: TFTP connection tracking"
+	}
+
+	chain accept_from_lan {
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 74735 bytes 5956001 accept comment "!fw4: accept lan IPv4 traffic"
+	}
+
+	chain accept_to_lan {
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 122 bytes 41167 accept comment "!fw4: accept lan IPv4 traffic"
+	}
+
+	chain input_wan {
+		meta nfproto ipv4 udp dport 68 counter packets 1 bytes 28 accept comment "!fw4: Allow-DHCP-Renew"
+		icmp type echo-request counter packets 47616 bytes 2044770 accept comment "!fw4: Allow-Ping"
+		meta nfproto ipv4 meta l4proto igmp counter packets 0 bytes 0 accept comment "!fw4: Allow-IGMP"
+		jump reject_from_wan
+	}
+
+	chain output_wan {
+		jump accept_to_wan
+	}
+
+	chain forward_wan {
+		meta nfproto ipv4 meta l4proto esp counter packets 0 bytes 0 jump accept_to_lan comment "!fw4: Allow-IPSec-ESP"
+		meta nfproto ipv4 udp dport 500 counter packets 0 bytes 0 jump accept_to_lan comment "!fw4: Allow-ISAKMP"
+		jump reject_to_wan
+		log prefix "reject wan forward: "
+	}
+
+	chain accept_to_wan {
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 82446 bytes 7806144 accept comment "!fw4: accept wan IPv4 traffic"
+	}
+
+	chain reject_from_wan {
+		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 11807 bytes 636751 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+	}
+
+	chain reject_to_wan {
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 0 bytes 0 log prefix "reject wan out: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+	}
+
+	chain input_Net2Shield {
+		jump reject_from_Net2Shield
+	}
+
+	chain output_Net2Shield {
+		jump accept_to_Net2Shield
+	}
+
+	chain forward_Net2Shield {
+		jump reject_to_Net2Shield
+		log prefix "reject Net2Shield forward: "
+	}
+
+	chain accept_to_Net2Shield {
+	}
+
+	chain reject_from_Net2Shield {
+	}
+
+	chain reject_to_Net2Shield {
+	}
+
+	chain input_Proton1VPN {
+		jump reject_from_Proton1VPN
+	}
+
+	chain output_Proton1VPN {
+		jump accept_to_Proton1VPN
+	}
+
+	chain forward_Proton1VPN {
+		jump reject_to_Proton1VPN
+		log prefix "reject Proton1VPN forward: "
+	}
+
+	chain accept_to_Proton1VPN {
+	}
+
+	chain reject_from_Proton1VPN {
+	}
+
+	chain reject_to_Proton1VPN {
+	}
+
+	chain dstnat {
+		type nat hook prerouting priority dstnat; policy accept;
+		jump upnp_prerouting comment "Hook into miniupnpd prerouting chain"
+	}
+
+	chain srcnat {
+		type nat hook postrouting priority srcnat; policy accept;
+		meta nfproto ipv4 oifname { "eth0", "eth5" } jump srcnat_wan comment "!fw4: Handle wan IPv4 srcnat traffic"
+		jump upnp_postrouting comment "Hook into miniupnpd postrouting chain"
+	}
+
+	chain srcnat_wan {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 wan traffic"
+	}
+
+	chain srcnat_Net2Shield {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 Net2Shield traffic"
+	}
+
+	chain srcnat_Proton1VPN {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 Proton1VPN traffic"
+	}
+
+	chain raw_prerouting {
+		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain raw_output {
+		type filter hook output priority raw; policy accept;
+	}
+
+	chain mangle_prerouting {
+		type filter hook prerouting priority mangle; policy accept;
+	}
+
+	chain mangle_postrouting {
+		type filter hook postrouting priority mangle; policy accept;
+	}
+
+	chain mangle_input {
+		type filter hook input priority mangle; policy accept;
+	}
+
+	chain mangle_output {
+		type route hook output priority mangle; policy accept;
+	}
+
+	chain mangle_forward {
+		type filter hook forward priority mangle; policy accept;
+		meta nfproto ipv4 iifname { "eth0", "eth5" } tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4 ingress MTU fixing"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4 egress MTU fixing"
+	}
+
+	chain upnp_forward {
+	}
+
+	chain upnp_prerouting {
+	}
+
+	chain upnp_postrouting {
+	}
+}

--- a/ruleset4.nft
+++ b/ruleset4.nft
@@ -119,16 +119,16 @@ table inet fw4 {
 	}
 
 	chain accept_from_lan {
-		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 76160 bytes 6066055 accept comment "!fw4: accept lan IPv4 traffic"
+		meta nfproto ipv4 iifname { "br-lan", "br-swlan", "eth2" } counter packets 105611 bytes 8473398 accept comment "!fw4: accept lan IPv4 traffic"
 	}
 
 	chain accept_to_lan {
-		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 122 bytes 41167 accept comment "!fw4: accept lan IPv4 traffic"
+		meta nfproto ipv4 oifname { "br-lan", "br-swlan", "eth2" } counter packets 159 bytes 53625 accept comment "!fw4: accept lan IPv4 traffic"
 	}
 
 	chain input_wan {
 		meta nfproto ipv4 udp dport 68 counter packets 1 bytes 28 accept comment "!fw4: Allow-DHCP-Renew"
-		icmp type echo-request counter packets 48068 bytes 2065218 accept comment "!fw4: Allow-Ping"
+		icmp type echo-request counter packets 68291 bytes 2960312 accept comment "!fw4: Allow-Ping"
 		meta nfproto ipv4 meta l4proto igmp counter packets 0 bytes 0 accept comment "!fw4: Allow-IGMP"
 		jump reject_from_wan
 	}
@@ -145,11 +145,11 @@ table inet fw4 {
 	}
 
 	chain accept_to_wan {
-		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 84059 bytes 7935770 accept comment "!fw4: accept wan IPv4 traffic"
+		meta nfproto ipv4 oifname { "eth0", "eth5" } counter packets 114619 bytes 10455016 accept comment "!fw4: accept wan IPv4 traffic"
 	}
 
 	chain reject_from_wan {
-		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 11966 bytes 649666 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
+		meta nfproto ipv4 iifname { "eth0", "eth5" } counter packets 15981 bytes 861785 log prefix "reject wan in: " jump handle_reject comment "!fw4: reject wan IPv4 traffic"
 	}
 
 	chain reject_to_wan {
@@ -582,7 +582,7 @@ table inet dscpclassify {
 		ip daddr { 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15 } udp dport 3478-3481 udp sport 50040-50059 counter packets 0 bytes 0 goto ct_set_af21 comment "Microsoft Teams sharing"
 		meta l4proto udp ip daddr { 66.22.196.0/22, 66.22.204.0/22, 66.22.246.0/24 } counter packets 0 bytes 0 goto ct_set_ef comment "Discord VoIP"
 		ip daddr 17.0.0.0/8 th sport { 16384-16387, 16393-16402 } counter packets 0 bytes 0 goto ct_set_af41 comment "Apple FaceTime"
-		meta l4proto icmp counter packets 0 bytes 0 goto ct_set_cs5 comment "ICMP"
+		meta l4proto icmp counter packets 6 bytes 504 goto ct_set_cs5 comment "ICMP"
 		udp dport != { 80, 443 } ip saddr 192.168.1.100 counter packets 0 bytes 0 goto ct_set_cs4 comment "Game Console non-HTTP"
 		meta l4proto udp ip daddr 95.172.238.85 counter packets 0 bytes 0 goto ct_set_ef comment "Voipify VoIP"
 		udp dport 3478 counter packets 0 bytes 0 goto ct_set_af41 comment "STUN various"


### PR DESCRIPTION
A typical error message currently looks like this:
Fri Jul 21 13:35:36 2023 daemon.warn dscpclassify: Rule contains an invalid dest_ip

This pull request changes this to:
Fri Jul 21 13:35:36 2023 daemon.warn dscpclassify: Rule 'DoH' contains an invalid dest_ip

All log call instances are similarly changed.
