### PR TITLE
OpenWrt 24.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,22 @@ This should be used in conjunction with layer-cake SQM queue with ctinfo configu
 The dscpclassify service uses the last 8 bits of the conntrack mark (0x000000ff).
 
 # Classification modes
-The service supports three modes for classifying and DSCP marking connections outlined below.
+The service uses three methods for classifying and DSCP marking connections outlined below.
 
-### Dynamic classification
-Connections that do not match a pre-specified rule will be dynamically classified by the service via two mechanisms.
+### 1. User rules
+The service will first attempt to classify new connections using rules specified by the user in the config file.
+
+These follow a similar syntax to the OpenWrt firewall config and can match upon source/destination ports and IPs, firewall zones etc.
+
+The rules support the use of nft sets, which could be dynamically updated from external sources such as dnsmasq.
+
+### 2. Client DSCP hinting
+The service can be configured to apply the DSCP mark supplied by a non WAN originating client.
+
+This function ignores CS6 and CS7 classes to avoid abuse from inappropriately configed LAN clients such as IoT devices.
+
+### 3. Dynamic classification
+Connections that do not match a user rule or client hint will be dynamically classified by the service to reduce their priority.
 
 #### Multi-connection client port detection for detecting P2P traffic
 These connections are classified as Low Effort (LE) by default and therefore prioritised below Best Effort traffic when using the layer-cake qdisc.
@@ -17,18 +29,6 @@ These connections are classified as Low Effort (LE) by default and therefore pri
 These connections are classified as High-Throughput (AF13) by default and therefore prioritised as follows by cake:
   * diffserv3/4: Equal to besteffort (CS0) traffic.
   * diffserv8: Below besteffort (CS0) traffic, but above low effort (LE) traffic.
-
-### Client DSCP hinting
-The service can be configured to apply the DSCP mark supplied by a non WAN originating client.
-
-This function ignores CS6 and CS7 classes to avoid abuse from inappropriately configed LAN clients such as IoT devices.
-
-### User rules
-The service will first attempt to classify new connections using rules specified by the user in the config file.
-
-These follow a similar syntax to the OpenWrt firewall config and can match upon source/destination ports and IPs, firewall zones etc.
-
-The rules support the use of nft sets, which could be dynamically updated from external sources such as dsnmasq.
 
 ## Service architecture
 ![image](https://user-images.githubusercontent.com/46714706/188151111-9167e54d-482e-4584-b43b-0759e0ad7561.png)

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -35,7 +35,7 @@ define cs6 = 48
 define cs7 = 56
 
 ## Include variable table content
-include "/tmp/etc/dscpclassify-pre.include"
+include "/tmp/etc/dscpclassify.d/pre-include.nft"
 
 table inet dscpclassify {
     ## Classify connections to the router
@@ -121,4 +121,4 @@ table inet dscpclassify {
 }
 
 ## Include configurable rules
-include "/tmp/etc/dscpclassify-post.include"
+include "/tmp/etc/dscpclassify.d/post-include.nft"

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -1,13 +1,11 @@
 #!/usr/sbin/nft -f
 
 ## Masks for extracting/storing data in the conntrack mark
-define ct_dscp = 0x0000003f
-define ct_dyn = 0x00000080
-define ct_dyn_static_dscp = 0x000000ff
-define ct_static = 0x00000040
-define ct_unused = 0xffffff00
-define ct_unused_dscp = 0xffffff3f
-define ct_unused_dyn = 0xffffff80
+define ct_dscp = 0x0000003f         # 00111111
+define ct_dynamic = 0x00000080      # 10000000
+define ct_processed = 0x00000040    # 01000000
+define ct_service = 0x000000ff      # 11111111
+define ct_unused = 0xffffff00       # 11111111111111111111111100000000
 
 ## DSCP classification values
 define cs0 = 0
@@ -42,16 +40,16 @@ table inet dscpclassify {
     chain input {
         type filter hook input priority 2; policy accept
         iif "lo" return
-        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
-        ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
+        ct mark and $ct_service == 0 ct direction original jump static_classify
+        ct mark and $ct_dynamic == $ct_dynamic jump dynamic_classify
     }
 
     ## Classify and DSCP mark connections from/forwarded via the router
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
         oif "lo" return
-        ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
-        ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
+        ct mark and $ct_service == 0 ct direction original jump static_classify
+        ct mark and $ct_dynamic == $ct_dynamic jump dynamic_classify
 
         ## DSCP marking rules are added here by the init script
     }
@@ -63,7 +61,7 @@ table inet dscpclassify {
         meta l4proto != { tcp, udp } goto ct_set_cs0
 
         ## Set the dynamic conntrack bit on unclassified connections
-        ct mark set ct mark and $ct_unused or $ct_dyn
+        ct mark set ct mark and $ct_unused or $ct_dynamic
     }
 
     chain dynamic_classify {
@@ -86,7 +84,7 @@ table inet dscpclassify {
 
     chain dynamic_classify_reply {
         ## Established connection
-        ct reply packets 1 jump established_connection
+        ct mark and $ct_processed != $ct_processed ct mark set ct mark or $ct_processed jump established_connection
 
         ## Assess threaded client connections (i.e. P2P) for classification
         ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -41,7 +41,7 @@ table inet dscpclassify {
     ## Classify connections to the router
     chain input {
         type filter hook input priority 2; policy accept
-        meta iifname "lo" return
+        iif "lo" return
         ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
     }
@@ -49,7 +49,7 @@ table inet dscpclassify {
     ## Classify and DSCP mark connections from/forwarded via the router
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
-        meta oifname "lo" return
+        oif "lo" return
         ct mark and $ct_dyn_static_dscp == 0 ct direction original jump static_classify
         ct mark and $ct_dyn == $ct_dyn jump dynamic_classify
 

--- a/etc/dscpclassify.d/verdicts.nft
+++ b/etc/dscpclassify.d/verdicts.nft
@@ -117,7 +117,7 @@ table inet dscpclassify {
 
     ## Set conntrack DSCP mark without modifying unused bits
     chain ct_set_cs0 {
-        ct mark set ct mark and $ct_unused or $cs0 or $ct_static
+        ct mark set ct mark and $ct_unused or $cs0 or $ct_processed
     }
 
     chain ct_set_le {

--- a/etc/dscpclassify.d/verdicts.nft
+++ b/etc/dscpclassify.d/verdicts.nft
@@ -96,8 +96,8 @@ table inet dscpclassify {
     }
 
     chain dscp_set_va {
-        ip dscp set 44
-        ip6 dscp set 44
+        ip dscp set $va
+        ip6 dscp set $va
     }
 
     chain dscp_set_ef {

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -43,7 +43,7 @@ delete_includes() {
 }
 
 delete_table() {
-	nft delete table inet dscpclassify 2>/dev/null
+	nft destroy table inet dscpclassify
 }
 
 cleanup_service() {
@@ -366,7 +366,7 @@ create_user_set() {
 	parse_set_flags || return 1
 
 	check_set_against_existing "$name" "$type" "$comment" "$size" "$flags" "$timeout" || {
-		[ "$?" = 1 ] && post_include "delete set inet dscpclassify $name"
+		[ "$?" = 1 ] && post_include "destroy set inet dscpclassify $name"
 		post_include "add set inet dscpclassify $name { type $type; ${timeout:+timeout $timeout;} ${size:+size $size;} ${flags:+flags $flags;} ${auto_merge:+auto-merge;} ${comment:+comment \"$comment\";} }"
 	}
 

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -17,6 +17,7 @@ MAPS="/etc/dscpclassify.d/maps.nft"
 
 log() {
 	logger -t dscpclassify -p "daemon.$1" "$2"
+	[ "$DEBUG" = 1 ] && echo "$2"
 }
 
 create_debug_file() {
@@ -43,7 +44,7 @@ delete_includes() {
 }
 
 delete_table() {
-	nft destroy table inet dscpclassify
+	nft destroy table inet dscpclassify &>/dev/null
 }
 
 cleanup_service() {
@@ -619,19 +620,19 @@ create_threaded_client_rule() {
 		return 1
 	}
 
-	post_include "destroy set inet dscpclassify tc_detect"
+	check_set_exists tc_detect && post_include "destroy set inet dscpclassify tc_detect"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
-	post_include "destroy set inet dscpclassify tc_detect6"
+	check_set_exists tc_detect6 && post_include "destroy set inet dscpclassify tc_detect6"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
-	post_include "destroy set inet dscpclassify tc_orig_bulk"
+	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
-	post_include "destroy set inet dscpclassify tc_orig_bulk6"
+	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 
-	post_include "destroy set inet dscpclassify tc_reply_bulk"
+	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
-	post_include "destroy set inet dscpclassify tc_reply_bulk6"
+	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 }
 
@@ -654,9 +655,9 @@ create_threaded_service_rule() {
 		return 1
 	}
 
-	post_include "destroy set inet dscpclassify ts_detect"
+	check_set_exists ts_detect && post_include "destroy set inet dscpclassify ts_detect"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
-	post_include "destroy set inet dscpclassify ts_detect6"
+	check_set_exists ts_detect6 && post_include "destroy set inet dscpclassify ts_detect6"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
 
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
@@ -774,8 +775,7 @@ setup() {
 
 	[ "$action" = "reload" ] && flush_table
 
-	nft_result="$(nft -f "$MAIN" 2>&1)"
-	nft -f "$MAIN" || {
+	nft_result="$(nft -f "$MAIN" 2>&1)" || {
 		log err "Failed to load main.nft with status: $?"
 		return 1
 	}

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # shellcheck disable=SC3043,SC3003,SC2019,SC2018,SC3020,SC3057
 
-START=20
+START=50
 USE_PROCD=1
 
 DEBUG=1

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -3,38 +3,66 @@
 
 START=20
 USE_PROCD=1
-DEBUG=0
+
+DEBUG=1
+DEBUG_FILE="/tmp/dscpclassify.debug"
+
+INCLUDES_PATH="/tmp/etc/dscpclassify.d"
+PRE_INCLUDE="${INCLUDES_PATH}/pre-include.nft"
+POST_INCLUDE="${INCLUDES_PATH}/post-include.nft"
+
+MAIN="/etc/dscpclassify.d/main.nft"
+VERDICTS="/etc/dscpclassify.d/verdicts.nft"
+MAPS="/etc/dscpclassify.d/maps.nft"
 
 log() {
 	logger -t dscpclassify -p "daemon.$1" "$2"
 }
 
-create_path() {
-	mkdir -p "$1" && return 0
-	log err "Unable to create '$1' path"
-	return 1
+create_debug_file() {
+	local action="$1"
+	{
+		echo "dscpclassify ${action}: $(date)"
+		echo $'\n'"<--- ${PRE_INCLUDE} --->"
+		[ -f "$PRE_INCLUDE" ] && cat "$PRE_INCLUDE"
+		echo $'\n'"<--- ${POST_INCLUDE} --->"
+		[ -f "$POST_INCLUDE" ] && cat "$POST_INCLUDE"
+		echo $'\n'"<--- nft -f ${MAIN} --->"
+		echo "$nft_result"
+		echo $'\n'"<--- nft list table inet dscpclassify --->"
+		nft list table inet dscpclassify 2>&1
+	} > "$DEBUG_FILE"
+}
+
+delete_debug_file() {
+	rm -f "$DEBUG_FILE"
 }
 
 delete_includes() {
-	rm -f "/tmp/etc/dscpclassify-pre.include"
-	rm -f "/tmp/etc/dscpclassify-post.include"
+	rm -rf "$INCLUDES_PATH"
 }
 
 delete_table() {
 	nft delete table inet dscpclassify 2>/dev/null
 }
 
-cleanup() {
+cleanup_service() {
+	delete_debug_file
 	delete_includes
 	delete_table
 }
 
+cleanup_setup() {
+	delete_debug_file
+	delete_includes
+}
+
 pre_include() {
-	echo "$1" >>"/tmp/etc/dscpclassify-pre.include"
+	echo "$1" >>"$PRE_INCLUDE"
 }
 
 post_include() {
-	echo "$1" >>"/tmp/etc/dscpclassify-post.include"
+	echo "$1" >>"$POST_INCLUDE"
 }
 
 list_append() {
@@ -645,6 +673,8 @@ create_dscp_mark_rule() {
 }
 
 create_pre_include() {
+	rm -f "$PRE_INCLUDE"
+
 	pre_include "define lan = { $(mklist "$lan" ", " "\"") }"
 	pre_include "define wan = { $(mklist "$wan" ", " "\"") }"
 
@@ -654,11 +684,13 @@ create_pre_include() {
 	check_set_exists threaded_services || pre_include "add set inet dscpclassify threaded_services { type ipv4_addr . ipv4_addr . inet_service . inet_proto; flags timeout; }"
 	check_set_exists threaded_services6 || pre_include "add set inet dscpclassify threaded_services6 { type ipv6_addr . ipv6_addr . inet_service . inet_proto; flags timeout; }"
 
-	pre_include "include \"/etc/dscpclassify.d/verdicts.nft\""
-	pre_include "include \"/etc/dscpclassify.d/maps.nft\""
+	pre_include "include \"${VERDICTS}\""
+	pre_include "include \"${MAPS}\""
 }
 
 create_post_include() {
+	rm -f "$POST_INCLUDE"
+
 	create_client_hints_rule || return 1
 
 	config_foreach create_user_set set   # depreciating in favour of 'ipset' section name for consistency with fw4
@@ -701,54 +733,79 @@ get_zones() {
 }
 
 setup() {
-	local action lan wan
+	local action="$1"
+	local lan wan
 
-	delete_includes
-	action="$1"
+	cleanup_setup
 
-	config_load dscpclassify || return 1
+	config_load dscpclassify || {
+		log err "Failed to load config file"
+		return 1
+	}
 	config_get_bool DEBUG global debug "$DEBUG"
 
-	get_zones || return 0
+	get_zones || {
+		log notice "Deferring ${action} because lan/wan firewall zones are unavailable"
+		return 0
+	}
 
 	[ "$action" = "start" ] && delete_table
 
-	create_path "/tmp/etc" || return 1
-	create_pre_include || return 1
-	create_post_include || return 1
+	mkdir -p "$INCLUDES_PATH" || {
+		log err "Failed to create path: ${INCLUDES_PATH}"
+		return 1
+	}
+	create_pre_include || {
+		log err "Failed to create pre-include rules"
+		return 1
+	}
+	create_post_include || {
+		log err "Failed to create post-include rules"
+		return 1
+	}
 
 	[ "$action" = "reload" ] && flush_table
 
-	nft -f "/etc/dscpclassify.d/main.nft" || return 1
-	[ "$DEBUG" != 1 ] && delete_includes
+	nft_result="$(nft -f "$MAIN" 2>&1)"
+	nft -f "$MAIN" || {
+		log err "Failed to load main.nft with status: $?"
+		return 1
+	}
 
+	log notice "Service ${action}ed"
 	return 0
+}
+
+setup_failed() {
+	local action="$1"
+	log err "Service ${action} failed"
+	[ "$DEBUG" = 1 ] && create_debug_file "$action"
+	delete_includes
+	delete_table
 }
 
 start_service() {
 	setup start || {
-		log err "Service start failed"
-		[ "$DEBUG" != 1 ] && cleanup
+		setup_failed start
 		return 1
 	}
-	log notice "Service started"
+	cleanup_setup
 }
 
 reload_service() {
 	/etc/init.d/dscpclassify status &>/dev/null || {
-		echo "The dscpclassify service does not appear to be loaded."
+		echo "The dscpclassify service is not loaded."
 		return 1
 	}
 
 	setup reload || {
-		log err "Service reload failed"
-		[ "$DEBUG" != 1 ] && cleanup
+		setup_failed reload
 		return 1
 	}
-	log notice "Service reloaded"
+	cleanup_setup
 }
 
 stop_service() {
-	cleanup
+	cleanup_service
 	log notice "Service stopped"
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -619,13 +619,19 @@ create_threaded_client_rule() {
 		return 1
 	}
 
+	post_include "destroy set inet dscpclassify tc_detect"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
+	post_include "destroy set inet dscpclassify tc_detect6"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
+	post_include "destroy set inet dscpclassify tc_orig_bulk"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "destroy set inet dscpclassify tc_orig_bulk6"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 
+	post_include "destroy set inet dscpclassify tc_reply_bulk"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "destroy set inet dscpclassify tc_reply_bulk6"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
 }
 
@@ -648,7 +654,9 @@ create_threaded_service_rule() {
 		return 1
 	}
 
+	post_include "destroy set inet dscpclassify ts_detect"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
+	post_include "destroy set inet dscpclassify ts_detect6"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
 
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -4,9 +4,7 @@
 START=50
 USE_PROCD=1
 
-DEBUG=1
 DEBUG_FILE="/tmp/dscpclassify.debug"
-
 INCLUDES_PATH="/tmp/etc/dscpclassify.d"
 PRE_INCLUDE="${INCLUDES_PATH}/pre-include.nft"
 POST_INCLUDE="${INCLUDES_PATH}/post-include.nft"
@@ -15,13 +13,17 @@ MAIN="/etc/dscpclassify.d/main.nft"
 VERDICTS="/etc/dscpclassify.d/verdicts.nft"
 MAPS="/etc/dscpclassify.d/maps.nft"
 
+debug=1
+nft_result=""
+
 log() {
 	logger -t dscpclassify -p "daemon.$1" "$2"
-	[ "$DEBUG" = 1 ] && echo "$2"
+	case "$1" in
+	warning | err) echo "$2" ;;
+	esac
 }
 
 create_debug_file() {
-	local action="$1"
 	{
 		echo "dscpclassify ${action}: $(date)"
 		echo $'\n'"<--- ${PRE_INCLUDE} --->"
@@ -43,14 +45,14 @@ delete_includes() {
 	rm -rf "$INCLUDES_PATH"
 }
 
-delete_table() {
+destroy_table() {
 	nft destroy table inet dscpclassify &>/dev/null
 }
 
 cleanup_service() {
+	destroy_table
 	delete_debug_file
 	delete_includes
-	delete_table
 }
 
 cleanup_setup() {
@@ -681,12 +683,22 @@ create_dscp_mark_rule() {
 	post_include "add rule inet dscpclassify postrouting ct mark and \$ct_dscp vmap @ct_dscp"
 }
 
+create_flush_actions() {
+	for chain in $(nft -j list chains | jsonfilter -e '@.nftables[@.chain.table="dscpclassify"].chain.name'); do
+		pre_include "flush chain inet dscpclassify ${chain}"
+	done
+	for map in $(nft -j list maps | jsonfilter -e '@.nftables[@.map.table="dscpclassify"].map.name'); do
+		pre_include "flush map inet dscpclassify ${map}"
+	done
+}
+
 create_pre_include() {
 	rm -f "$PRE_INCLUDE"
 
 	pre_include "define lan = { $(mklist "$lan" ", " "\"") }"
 	pre_include "define wan = { $(mklist "$wan" ", " "\"") }"
 
+	[ "$action" = "reload" ] && create_flush_actions 
 	pre_include "add table inet dscpclassify"
 	check_set_exists threaded_clients || pre_include "add set inet dscpclassify threaded_clients { type ipv4_addr . inet_service . inet_proto; flags timeout; }"
 	check_set_exists threaded_clients6 || pre_include "add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }"
@@ -712,15 +724,6 @@ create_post_include() {
 	create_dscp_mark_rule || return 1
 }
 
-flush_table() {
-	for i in $(nft -j list chains | jsonfilter -e '@.nftables[@.chain.table="dscpclassify"].chain.name'); do
-		nft flush chain inet dscpclassify "$i"
-	done
-	for i in $(nft -j list maps | jsonfilter -e '@.nftables[@.map.table="dscpclassify"].map.name'); do
-		nft flush map inet dscpclassify "$i"
-	done
-}
-
 get_zones() {
 	local dev lan_zones wan_zones
 
@@ -742,7 +745,6 @@ get_zones() {
 }
 
 setup() {
-	local action="$1"
 	local lan wan
 
 	cleanup_setup
@@ -751,14 +753,14 @@ setup() {
 		log err "Failed to load config file"
 		return 1
 	}
-	config_get_bool DEBUG global debug "$DEBUG"
+	config_get_bool debug global debug "$debug"
 
 	get_zones || {
 		log notice "Deferring ${action} because lan/wan firewall zones are unavailable"
 		return 0
 	}
 
-	[ "$action" = "start" ] && delete_table
+	[ "$action" = "start" ] && destroy_table
 
 	mkdir -p "$INCLUDES_PATH" || {
 		log err "Failed to create path: ${INCLUDES_PATH}"
@@ -773,8 +775,6 @@ setup() {
 		return 1
 	}
 
-	[ "$action" = "reload" ] && flush_table
-
 	nft_result="$(nft -f "$MAIN" 2>&1)" || {
 		log err "Failed to load main.nft with status: $?"
 		return 1
@@ -785,16 +785,15 @@ setup() {
 }
 
 setup_failed() {
-	local action="$1"
-	log err "Service ${action} failed"
-	[ "$DEBUG" = 1 ] && create_debug_file "$action"
+	log warning "Service ${action} failed"
+	[ "$debug" = 1 ] && create_debug_file
+	destroy_table
 	delete_includes
-	delete_table
 }
 
 start_service() {
-	setup start || {
-		setup_failed start
+	setup || {
+		setup_failed
 		return 1
 	}
 	cleanup_setup
@@ -802,12 +801,12 @@ start_service() {
 
 reload_service() {
 	/etc/init.d/dscpclassify status &>/dev/null || {
-		echo "The dscpclassify service is not loaded."
+		echo "The dscpclassify service is not loaded"
 		return 1
 	}
 
-	setup reload || {
-		setup_failed reload
+	setup || {
+		setup_failed
 		return 1
 	}
 	cleanup_setup


### PR DESCRIPTION
## Overview
* OpenWrt 24.10 fixes
  * The service now explicitly destroys meter sets used for the threaded client/server detection as these were causing failures during reload (https://github.com/jeverley/dscpclassify/issues/27)     _Thank you @Sam-arch99 for helping troubleshoot this._
* The service now creates a debug file `/tmp/dscpclassify.debug` when start/reload fails 
* Use ct_processed bit rather than relying on first reply packet for established_connection counting, this allows consideration of connections established before the service started (https://github.com/jeverley/dscpclassify/issues/26)
* Optimised loopback match @ldir-EDB0 (https://github.com/jeverley/dscpclassify/commit/c9b53e94af8bc7b0ed7eb928254f5f32b41de516)
* Improved service reload performance

## Addresses issues
- https://github.com/jeverley/dscpclassify/issues/27
- https://github.com/jeverley/dscpclassify/issues/26