### PR TITLE
Ensure that CS0 class mark is set on outbound packets

### DIFF
--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -40,16 +40,16 @@ table inet dscpclassify {
     chain input {
         type filter hook input priority 2; policy accept
         iif "lo" return
-        ct mark and $ct_service == 0 ct direction original jump static_classify
-        ct mark and $ct_dynamic == $ct_dynamic jump dynamic_classify
+        ct mark & $ct_service == 0 ct direction original jump static_classify
+        ct mark & $ct_dynamic != 0 jump dynamic_classify
     }
 
     ## Classify and DSCP mark connections from/forwarded via the router
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
         oif "lo" return
-        ct mark and $ct_service == 0 ct direction original jump static_classify
-        ct mark and $ct_dynamic == $ct_dynamic jump dynamic_classify
+        ct mark & $ct_service == 0 ct direction original jump static_classify
+        ct mark & $ct_dynamic != 0 jump dynamic_classify
 
         ## DSCP marking rules are added here by the init script
     }
@@ -61,7 +61,7 @@ table inet dscpclassify {
         meta l4proto != { tcp, udp } goto ct_set_cs0
 
         ## Set the dynamic conntrack bit on unclassified connections
-        ct mark set ct mark and $ct_unused or $ct_dynamic
+        ct mark set ct mark & $ct_unused | $ct_dynamic
     }
 
     chain dynamic_classify {
@@ -84,7 +84,7 @@ table inet dscpclassify {
 
     chain dynamic_classify_reply {
         ## Established connection
-        ct mark and $ct_processed != $ct_processed ct mark set ct mark or $ct_processed jump established_connection
+        ct mark & $ct_processed == 0 ct mark set ct mark | $ct_processed jump established_connection
 
         ## Assess threaded client connections (i.e. P2P) for classification
         ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply

--- a/etc/dscpclassify.d/verdicts.nft
+++ b/etc/dscpclassify.d/verdicts.nft
@@ -117,94 +117,94 @@ table inet dscpclassify {
 
     ## Set conntrack DSCP mark without modifying unused bits
     chain ct_set_cs0 {
-        ct mark set ct mark and $ct_unused or $cs0 or $ct_processed
+        ct mark set ct mark & $ct_unused | $cs0 | $ct_processed
     }
 
     chain ct_set_le {
-        ct mark set ct mark and $ct_unused or $lephb
+        ct mark set ct mark & $ct_unused | $lephb
     }
 
     chain ct_set_cs1 {
-        ct mark set ct mark and $ct_unused or $cs1
+        ct mark set ct mark & $ct_unused | $cs1
     }
 
     chain ct_set_af11 {
-        ct mark set ct mark and $ct_unused or $af11
+        ct mark set ct mark & $ct_unused | $af11
     }
 
     chain ct_set_af12 {
-        ct mark set ct mark and $ct_unused or $af12
+        ct mark set ct mark & $ct_unused | $af12
     }
 
     chain ct_set_af13 {
-        ct mark set ct mark and $ct_unused or $af13
+        ct mark set ct mark & $ct_unused | $af13
     }
 
     chain ct_set_cs2 {
-        ct mark set ct mark and $ct_unused or $cs2
+        ct mark set ct mark & $ct_unused | $cs2
     }
 
     chain ct_set_af21 {
-        ct mark set ct mark and $ct_unused or $af21
+        ct mark set ct mark & $ct_unused | $af21
     }
 
     chain ct_set_af22 {
-        ct mark set ct mark and $ct_unused or $af22
+        ct mark set ct mark & $ct_unused | $af22
     }
 
     chain ct_set_af23 {
-        ct mark set ct mark and $ct_unused or $af23
+        ct mark set ct mark & $ct_unused | $af23
     }
 
     chain ct_set_cs3 {
-        ct mark set ct mark and $ct_unused or $cs3
+        ct mark set ct mark & $ct_unused | $cs3
     }
 
     chain ct_set_af31 {
-        ct mark set ct mark and $ct_unused or $af31
+        ct mark set ct mark & $ct_unused | $af31
     }
 
     chain ct_set_af32 {
-        ct mark set ct mark and $ct_unused or $af32
+        ct mark set ct mark & $ct_unused | $af32
     }
 
     chain ct_set_af33 {
-        ct mark set ct mark and $ct_unused or $af33
+        ct mark set ct mark & $ct_unused | $af33
     }
 
     chain ct_set_cs4 {
-        ct mark set ct mark and $ct_unused or $cs4
+        ct mark set ct mark & $ct_unused | $cs4
     }
 
     chain ct_set_af41 {
-        ct mark set ct mark and $ct_unused or $af41
+        ct mark set ct mark & $ct_unused | $af41
     }
 
     chain ct_set_af42 {
-        ct mark set ct mark and $ct_unused or $af42
+        ct mark set ct mark & $ct_unused | $af42
     }
 
     chain ct_set_af43 {
-        ct mark set ct mark and $ct_unused or $af43
+        ct mark set ct mark & $ct_unused | $af43
     }
 
     chain ct_set_cs5 {
-        ct mark set ct mark and $ct_unused or $cs5
+        ct mark set ct mark & $ct_unused | $cs5
     }
 
     chain ct_set_va {
-        ct mark set ct mark and $ct_unused or $va
+        ct mark set ct mark & $ct_unused | $va
     }
 
     chain ct_set_ef {
-        ct mark set ct mark and $ct_unused or $ef
+        ct mark set ct mark & $ct_unused | $ef
     }
 
     chain ct_set_cs6 {
-        ct mark set ct mark and $ct_unused or $cs6
+        ct mark set ct mark & $ct_unused | $cs6
     }
 
     chain ct_set_cs7 {
-        ct mark set ct mark and $ct_unused or $cs7
+        ct mark set ct mark & $ct_unused | $cs7
     }
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -677,10 +677,9 @@ create_dscp_mark_rule() {
 	local wmm
 
 	config_get_bool wmm global wmm 0
-	[ "$wmm" = 1 ] && {
-		post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark and \$ct_dscp vmap @ct_wmm"
-	}
-	post_include "add rule inet dscpclassify postrouting ct mark and \$ct_dscp vmap @ct_dscp"
+	[ "$wmm" = 1 ] && post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark and (\$ct_dscp | \$ct_processed) vmap @ct_wmm"
+
+	post_include "add rule inet dscpclassify postrouting ct mark and (\$ct_dscp | \$ct_processed) vmap @ct_dscp"
 }
 
 create_flush_actions() {


### PR DESCRIPTION
This change ensures that connections with a CS0 conntrack mark have their DSCP mark set to CS0.