### PR TITLE
Ensure client class hints that occur after the first packet are applied

### DIFF
--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -79,46 +79,18 @@ table inet dscpclassify {
         ## Handle connection replies
         ct direction reply goto dynamic_classify_reply
 
-        ## Assess threaded client connections (i.e. P2P) for classification
-        ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client
-        ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client
-
-        ## Assess threaded service connections for classification
-        ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
-        ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
+        ## Dynamic rules are added here by the init script
     }
 
     chain dynamic_classify_reply {
         ## Established connection
         ct mark & $ct_processed == 0 ct mark set ct mark | $ct_processed jump established_connection
 
-        ## Assess threaded client connections (i.e. P2P) for classification
-        ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply
-        ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply
-
-        ## Assess threaded service connections for classification
-        ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
-        ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
+        ## Dynamic rules are added here by the init script
     }
 
     chain established_connection {
-        ## Threaded service and multi-connection client rules are added here by the init script
-    }
-
-    chain threaded_client {
-        ## Threaded client rules are added here by the init script
-    }
-
-    chain threaded_client_reply {
-        ## Threaded client rules are added here by the init script
-    }
-
-    chain threaded_service {
-        ## Threaded service rules are added here by the init script
-    }
-
-    chain threaded_service_reply {
-        ## Threaded service rules are added here by the init script
+        ## Dynamic connection detection rules are added here by the init script
     }
 }
 

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -40,21 +40,23 @@ table inet dscpclassify {
     chain input {
         type filter hook input priority 2; policy accept
         iif "lo" return
-        ct mark & $ct_service == 0 ct direction original jump static_classify
-        ct mark & $ct_dynamic != 0 jump dynamic_classify
+        ct mark & $ct_service == 0 ct direction original jump rule_classify
+        # Client hints jump added here by the init script if enabled
+        # Dynamic classify jump added here by the init script if enabled
     }
 
     ## Classify and DSCP mark connections from/forwarded via the router
     chain postrouting {
         type filter hook postrouting priority 2; policy accept
         oif "lo" return
-        ct mark & $ct_service == 0 ct direction original jump static_classify
-        ct mark & $ct_dynamic != 0 jump dynamic_classify
+        ct mark & $ct_service == 0 ct direction original jump rule_classify
+        # Client hints jump added here by the init script if enabled
+        # Dynamic classify jump added here by the init script if enabled
 
         ## DSCP marking rules are added here by the init script
     }
 
-    chain static_classify {
+    chain rule_classify {
         ## User defined rules in '/etc/config/dscpclassify' are inserted here by the init script
 
         ## Non TCP/UDP unclassified connections are Best Effort (CS0)
@@ -65,14 +67,12 @@ table inet dscpclassify {
     }
 
     chain client_classify {
-        ## Assess client specified DSCP mark for classification
-	    ip dscp != { cs0, cs6, cs7 } ip dscp vmap @dscp_ct
-	    ip6 dscp != { cs0, cs6, cs7 } ip6 dscp vmap @dscp_ct
+        ## Assess client DSCP mark for classification
+        ip dscp != { cs0, cs6, cs7 } ip dscp vmap @dscp_ct
+        ip6 dscp != { cs0, cs6, cs7 } ip6 dscp vmap @dscp_ct
     }
 
     chain dynamic_classify {
-        ## The client hint classification jump is inserted here if enabled
-
         ## Unreplied connections are ignored by dynamic classification logic
         ct status and seen-reply != seen-reply return
 
@@ -86,8 +86,6 @@ table inet dscpclassify {
         ## Assess threaded service connections for classification
         ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service
         ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service
-
-        ## Dynamic rules are added here by the init script
     }
 
     chain dynamic_classify_reply {
@@ -101,8 +99,6 @@ table inet dscpclassify {
         ## Assess threaded service connections for classification
         ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply
         ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply
-
-        ## Dynamic rules are added here by the init script
     }
 
     chain established_connection {

--- a/etc/dscpclassify.d/main.nft
+++ b/etc/dscpclassify.d/main.nft
@@ -64,7 +64,15 @@ table inet dscpclassify {
         ct mark set ct mark & $ct_unused | $ct_dynamic
     }
 
+    chain client_classify {
+        ## Assess client specified DSCP mark for classification
+	    ip dscp != { cs0, cs6, cs7 } ip dscp vmap @dscp_ct
+	    ip6 dscp != { cs0, cs6, cs7 } ip6 dscp vmap @dscp_ct
+    }
+
     chain dynamic_classify {
+        ## The client hint classification jump is inserted here if enabled
+
         ## Unreplied connections are ignored by dynamic classification logic
         ct status and seen-reply != seen-reply return
 

--- a/etc/dscpclassify.d/verdicts.nft
+++ b/etc/dscpclassify.d/verdicts.nft
@@ -115,7 +115,7 @@ table inet dscpclassify {
         ip6 dscp set cs7
     }
 
-    ## Set conntrack DSCP mark without modifying unused bits
+    ## Set conntrack DSCP class without modifying unused bits
     chain ct_set_cs0 {
         ct mark set ct mark & $ct_unused | $cs0 | $ct_processed
     }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -789,8 +789,6 @@ setup() {
 		log err "Failed to load main.nft with status: $?"
 		return 1
 	}
-
-	log notice "Service ${action}ed"
 	return 0
 }
 
@@ -807,6 +805,7 @@ start_service() {
 		return 1
 	}
 	cleanup_setup
+	log notice "Service ${action}ed"
 	return 0
 }
 

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -19,6 +19,7 @@ MAPS="/etc/dscpclassify.d/maps.nft"
 CLASS_BULK=le
 CLASS_HIGH_THROUGHPUT=af13
 CLIENT_HINTS=1
+DYNAMIC_CLASSIFY=1
 THREADED_CLIENT_MIN_BYTES=10000
 THREADED_CLIENT_MIN_CONNECTIONS=10
 THREADED_SERVICE_MIN_BYTES=1000000
@@ -597,25 +598,36 @@ create_user_rule() {
 	rule_verdict "$class" || return 1
 
 	[ -z "$daddr$saddr$daddr6$saddr6" ] && {
-		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $dport $iifname $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+		post_include "insert rule inet dscpclassify rule_classify $nfproto $l4proto $oifname $dport $iifname $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
 		return 0
 	}
 	[ -n "$daddr$saddr" ] && {
-		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $daddr $dport $iifname $saddr $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+		post_include "insert rule inet dscpclassify rule_classify $nfproto $l4proto $oifname $daddr $dport $iifname $saddr $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
 	}
 	[ -n "$daddr6$saddr6" ] && {
-		post_include "insert rule inet dscpclassify static_classify $nfproto $l4proto $oifname $daddr6 $dport $iifname $saddr6 $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
+		post_include "insert rule inet dscpclassify rule_classify $nfproto $l4proto $oifname $daddr6 $dport $iifname $saddr6 $sport ${counter:+counter} $verdict ${name:+comment \"$name\"}"
 	}
 	return 0
 }
 
-create_client_hints_rule() {
+create_client_hints_jump() {
 	local client_hints
 
 	config_get_bool client_hints global client_hints $CLIENT_HINTS
 	[ "$client_hints" = 1 ] || return 0
 
-	post_include "insert rule inet dscpclassify dynamic_classify ct direction original iifname != \$wan jump client_classify"
+	post_include "add rule inet dscpclassify input ct mark & \$ct_dynamic != 0 ct direction original iifname != \$wan jump client_classify"
+	post_include "add rule inet dscpclassify postrouting ct mark & \$ct_dynamic != 0 ct direction original iifname != \$wan jump client_classify"
+}
+
+create_dynamic_classify_jump() {
+	local dynamic_classify
+
+	config_get_bool dynamic_classify global dynamic_classify $DYNAMIC_CLASSIFY
+	[ "$dynamic_classify" = 1 ] || return 0
+
+	post_include "add rule inet dscpclassify input ct mark & (\$ct_dynamic | \$ct_dscp) == \$ct_dynamic jump dynamic_classify"
+	post_include "add rule inet dscpclassify postrouting ct mark & (\$ct_dynamic | \$ct_dscp) == \$ct_dynamic jump dynamic_classify"
 }
 
 create_threaded_client_rule() {
@@ -636,21 +648,22 @@ create_threaded_client_rule() {
 		log err "Global option class_bulk contains an invalid DSCP class"
 		return 1
 	}
+	[ "$class_bulk" = "le" ] && class_bulk=lephb
 
 	check_set_exists tc_detect && post_include "destroy set inet dscpclassify tc_detect"
-	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
 	check_set_exists tc_detect6 && post_include "destroy set inet dscpclassify tc_detect6"
+	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
 	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
 
 	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
 }
 
 create_threaded_service_rule() {
@@ -671,21 +684,22 @@ create_threaded_service_rule() {
 		log err "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
 	}
+	[ "$class_high_throughput" = "le" ] && class_high_throughput=lephb
 
 	check_set_exists ts_detect && post_include "destroy set inet dscpclassify ts_detect"
-	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
 	check_set_exists ts_detect6 && post_include "destroy set inet dscpclassify ts_detect6"
+	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
 
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service goto ct_set_${class_high_throughput}"
+	post_include "add rule inet dscpclassify threaded_service ct mark set ct mark | \$${class_high_throughput} return"
 
 	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_${class_high_throughput}"
+	post_include "add rule inet dscpclassify threaded_service_reply ct mark set ct mark | \$${class_high_throughput} return"
 }
 
 create_dscp_mark_rule() {
@@ -730,7 +744,8 @@ create_post_include() {
 	config_foreach create_user_set ipset # section name consistent with fw4
 	config_foreach_reverse create_user_rule rule
 
-	create_client_hints_rule || return 1
+	create_client_hints_jump || return 1
+	create_dynamic_classify_jump || return 1
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
 

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -37,6 +37,7 @@ log() {
 }
 
 create_debug_file() {
+	# shellcheck disable=SC2154
 	{
 		echo "dscpclassify ${action}: $(date)"
 		echo $'\n'"<--- ${PRE_INCLUDE} --->"
@@ -81,56 +82,25 @@ post_include() {
 	echo "$1" >>"$POST_INCLUDE"
 }
 
-list_append() {
-	list="$list"$'\n'"$1"
-}
-
 config_foreach_reverse() {
+	local function="$1" type="$2"
 	local list
 
-	config_foreach list_append "$2"
+	# shellcheck disable=SC2329
+	list_append() {
+		list="$list"$'\n'"$1"
+	}
+	config_foreach list_append "$type"
 	list=$(echo "$list" | sort -r)
-
+	
+	shift 2
 	for config in $list; do
-		"$1" "$config" "$3"
+		"$function" "$config" "$@"
 	done
 }
 
-fw_zone_dev() {
-	local dev
-
-	dev="$(fw4 -q zone "$1" | sort -u)"
-	[ -n "$dev" ] || return 1
-
-	echo "$dev"
-}
-
-format_list() {
-	local items="$1" delimiter="$2" encapsulator="$3"
-	echo "$items" | tr '\n' ' ' | sed -e "s/^\s*/${encapsulator}/" -e "s/\s*$/${encapsulator}/" -e "s/\([^.]\)\s\+\([^.]\)/\1${encapsulator}${delimiter}${encapsulator}\2/g"
-}
-
-check_class() {
-	local class
-
-	class="$(echo "$1" | tr 'A-Z' 'a-z')"
-
-	case "$class" in
-	le) true ;;  # RFC-8622
-	be | df) class="cs0" ;;
-	cs0 | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7) true ;;
-	*) return 1 ;;
-	esac
-
-	echo "$class"
-}
-
-check_duration() {
-	echo "$1" | grep -q -E -e "^([1-9][0-9]*[smhd]){1,4}$"
-}
-
 convert_duration_to_seconds() {
-	local duration seconds
+	local seconds
 
 	duration="$(echo "$1" | sed -e 's/\([dhms]\)/\1 /g')"
 	for i in $duration; do
@@ -146,11 +116,43 @@ convert_duration_to_seconds() {
 	echo "$seconds"
 }
 
+dscp_class() {
+	local class="$1"
+
+	class="$(echo "$class" | tr 'A-Z' 'a-z')"
+	case "$class" in
+	le) true ;;  # RFC-8622
+	be | df) class="cs0" ;;
+	cs0 | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7) true ;;
+	*) return 1 ;;
+	esac
+
+	echo "$class"
+}
+
+format_list() {
+	local items="$1" delimiter="$2" encapsulator="$3"
+
+	echo "$items" | tr '\n' ' ' | sed -e "s/^\s*/${encapsulator}/" -e "s/\s*$/${encapsulator}/" -e "s/\([^.]\)\s\+\([^.]\)/\1${encapsulator}${delimiter}${encapsulator}\2/g"
+}
+
+fw_zone_devices() {
+	local dev
+
+	dev="$(fw4 -q zone "$1" | sort -u)"
+	[ -n "$dev" ] || return 1
+
+	echo "$dev"
+}
+
+check_duration() {
+	echo "$1" | grep -q -E -e "^([1-9][0-9]*[smhd]){1,4}$"
+}
+
 check_family() {
 	case "$1" in
 	ipv4 | ipv6) return 0 ;;
 	esac
-
 	return 1
 }
 
@@ -178,7 +180,6 @@ check_set_name() {
 		return 1
 		;;
 	esac
-
 	return 0
 }
 
@@ -189,7 +190,6 @@ check_set_size() {
 		log warning "Set contains an invalid maxelem option"
 		return 1
 	fi
-
 	return 0
 }
 
@@ -241,6 +241,7 @@ parse_rule_ports() {
 
 parse_rule_ips() {
 	for i in $1; do
+		# ipv4 address
 		echo "$i" | grep -q -E -e "^!?(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9])[.]){3}(([2]([0-4][0-9]|[5][0-5])|[0-1]?[0-9]?[0-9]))(/([0-9]|[12][0-9]|3[0-2]))?$" && {
 			case "$i" in
 			"!"*) ipv4_negate="$ipv4_negate ${i#*!}" ;;
@@ -249,6 +250,7 @@ parse_rule_ips() {
 			continue
 		}
 
+		# ipv6 address
 		echo "$i" | grep -q -E -e "^!?(([a-fA-F0-9]{1,4}|):){1,7}([a-fA-F0-9]{1,4}|:)(/[0-9]{1,3})?$" && {
 			case "$i" in
 			"!"*) ipv6_negate="$ipv6_negate ${i#*!}" ;;
@@ -257,6 +259,7 @@ parse_rule_ips() {
 			continue
 		}
 
+		# set name
 		echo "$i" | grep -q -E -e "^!?@\w+$" && {
 			case "$i" in
 			"!"*) ipset_negate="$ipset_negate ${i#*!}" ;;
@@ -264,6 +267,8 @@ parse_rule_ips() {
 			esac
 			continue
 		}
+
+		log warning "Invalid ip/set name: $i"
 		return 1
 	done
 }
@@ -415,7 +420,7 @@ rule_zone() {
 
 	[ -n "$2" ] || return 0
 
-	device="$(fw_zone_dev "$2")" || {
+	device="$(fw_zone_devices "$2")" || {
 		log warning "Rule contains an invalid $1 zone"
 		return 1
 	}
@@ -552,7 +557,7 @@ rule_verdict() {
 		log warning "Rule is missing the DSCP class option"
 		return 1
 	}
-	class="$(check_class "$class")" || {
+	class="$(dscp_class "$class")" || {
 		log warning "Rule contains an invalid DSCP class"
 		return 1
 	}
@@ -628,7 +633,7 @@ create_threaded_client_rule() {
 		return 1
 	fi
 	config_get class_bulk global class_bulk $CLASS_BULK
-	class_bulk="$(check_class "$class_bulk")" || {
+	class_bulk="$(dscp_class "$class_bulk")" || {
 		log err "Global option class_bulk contains an invalid DSCP class"
 		return 1
 	}
@@ -663,7 +668,7 @@ create_threaded_service_rule() {
 		return 1
 	}
 	config_get class_high_throughput global class_high_throughput $CLASS_HIGH_THROUGHPUT
-	class_high_throughput="$(check_class "$class_high_throughput")" || {
+	class_high_throughput="$(dscp_class "$class_high_throughput")" || {
 		log err "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
 	}
@@ -688,7 +693,7 @@ create_dscp_mark_rule() {
 	local wmm
 
 	config_get_bool wmm global wmm $WMM
-	
+
 	[ "$wmm" = 1 ] && post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark & \$ct_dscp vmap @ct_wmm"
 	post_include "add rule inet dscpclassify postrouting ct mark & \$ct_dscp vmap @ct_dscp"
 }
@@ -741,7 +746,7 @@ get_zones() {
 	config_get lan_zones global lan_zone "lan"
 
 	for i in $lan_zones; do
-		dev="$(fw_zone_dev "$i")" && lan="${lan:+$lan }$dev"
+		dev="$(fw_zone_devices "$i")" && lan="${lan:+$lan }$dev"
 	done
 	[ -n "$lan" ] || return 1
 
@@ -749,7 +754,7 @@ get_zones() {
 	config_get wan_zones global wan_zone "wan"
 
 	for i in $wan_zones; do
-		dev="$(fw_zone_dev "$i")" && wan="${wan:+$wan }$dev"
+		dev="$(fw_zone_devices "$i")" && wan="${wan:+$wan }$dev"
 	done
 	[ -n "$wan" ] || return 1
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -372,8 +372,8 @@ create_user_set() {
 	config_get_bool flag_interval "$1" interval
 
 	config_get entry "$1" entry
-	config_get element "$1" element # depreciate for naming consistency with fw4 (entry)
-	[ -n "$element" ] && log warning "The user set 'element' option is being depreciated in favour of 'entry' for consistency with fw4"
+	config_get element "$1" element # deprecate for naming consistency with fw4 (entry)
+	[ -n "$element" ] && log warning "The user set 'element' option is being deprecated in favour of 'entry' for consistency with fw4"
 
 	check_set_name "$name" || return 1
 	check_set_size "$size" || return 1
@@ -610,7 +610,7 @@ create_user_rule() {
 	return 0
 }
 
-create_client_hints_jump() {
+create_client_classify_jump() {
 	local client_hints
 
 	config_get_bool client_hints global client_hints $CLIENT_HINTS
@@ -633,10 +633,19 @@ create_dynamic_classify_jump() {
 destroy_threaded_client_rules() {
 	post_include "destroy chain inet dscpclassify threaded_client"
 	post_include "destroy chain inet dscpclassify threaded_client_reply"
+
+	check_set_exists threaded_clients && post_include "destroy set inet dscpclassify threaded_clients"
+	check_set_exists threaded_clients6 && post_include "destroy set inet dscpclassify threaded_clients6"
 }
 
 create_threaded_client_rules() {
 	local class_bulk threaded_client_min_bytes threaded_client_min_connections
+
+	config_get_bool dynamic_classify global dynamic_classify $DYNAMIC_CLASSIFY
+	[ "$dynamic_classify" = 1 ] || {
+		destroy_threaded_client_rules
+		return 0
+	}
 
 	config_get threaded_client_min_connections global threaded_client_min_connections $THREADED_CLIENT_MIN_CONNECTIONS
 	if ! check_uint "$threaded_client_min_connections" || [ "$threaded_client_min_connections" -lt 2 ]; then
@@ -654,15 +663,9 @@ create_threaded_client_rules() {
 		return 1
 	}
 
-	# Destroy up old meter sets
-	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
-	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
-	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
-	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
-
 	case "$class_bulk" in
 	le) class_bulk=lephb ;;  # RFC-8622
-	cs0) destroy_threaded_client_rules; return 0 ;; # Skip rule creation
+	cs0) destroy_threaded_client_rules; return 0 ;; # Skip rule creation as CS0 is the default
 	esac
 
 	# Create sets for matching threaded clients
@@ -670,8 +673,6 @@ create_threaded_client_rules() {
 	check_set_exists threaded_clients6 || post_include "add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }"
 
 	# Create threaded client detection rules
-	check_set_exists tc_detect && post_include "destroy set inet dscpclassify tc_detect"
-	check_set_exists tc_detect6 && post_include "destroy set inet dscpclassify tc_detect6"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
@@ -695,10 +696,19 @@ create_threaded_client_rules() {
 destroy_threaded_service_rules() {
 	post_include "destroy chain inet dscpclassify threaded_service"
 	post_include "destroy chain inet dscpclassify threaded_service_reply"
+
+	check_set_exists threaded_services && post_include "destroy set inet dscpclassify threaded_services"
+	check_set_exists threaded_services6 && post_include "destroy set inet dscpclassify threaded_services6"
 }
 
 create_threaded_service_rules() {
 	local class_high_throughput threaded_service_min_bytes threaded_service_min_connections
+
+	config_get_bool dynamic_classify global dynamic_classify $DYNAMIC_CLASSIFY
+	[ "$dynamic_classify" = 1 ] || {
+		destroy_threaded_service_rules
+		return 0
+	}
 
 	config_get threaded_service_min_connections global threaded_service_min_connections $THREADED_SERVICE_MIN_CONNECTIONS
 	if ! check_uint "$threaded_service_min_connections" || [ "$threaded_service_min_connections" -lt 2 ]; then
@@ -716,13 +726,9 @@ create_threaded_service_rules() {
 		return 1
 	}
 
-	# Destroy up old meter sets
-	check_set_exists ts_detect && post_include "destroy set inet dscpclassify ts_detect"
-	check_set_exists ts_detect6 && post_include "destroy set inet dscpclassify ts_detect6"
-
 	case "$class_bulk" in
 	le) class_bulk=lephb ;;  # RFC-8622
-	cs0) destroy_threaded_service_rules; return 0 ;; # Skip rule creation
+	cs0) destroy_threaded_service_rules; return 0 ;; # Skip rule creation as CS0 is the default
 	esac
 
 	# Create sets for matching threaded services
@@ -734,22 +740,22 @@ create_threaded_service_rules() {
 	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
 
 	# Create threaded service classification rule chains
+	post_include "add chain inet dscpclassify threaded_service"
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service ct mark set ct mark | \$${class_high_throughput} return"
 
+	post_include "add chain inet dscpclassify threaded_service_reply"
 	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply ct mark set ct mark | \$${class_high_throughput} return"
 
 	# Create jumps from dynamic_classify chain
-	post_include "add chain inet dscpclassify threaded_service"
 	post_include "add rule inet dscpclassify dynamic_classify ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service"
 	post_include "add rule inet dscpclassify dynamic_classify ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service"
 
-	post_include "add chain inet dscpclassify threaded_service_reply"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply"
 	post_include "add rule inet dscpclassify dynamic_classify_reply ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply"
 }
@@ -770,6 +776,16 @@ create_flush_actions() {
 	for map in $(nft -j list maps | jsonfilter -e '@.nftables[@.map.table="dscpclassify"].map.name'); do
 		pre_include "flush map inet dscpclassify ${map}"
 	done
+
+	# Destroy orphaned meter sets	
+	check_set_exists tc_detect && pre_include "destroy set inet dscpclassify tc_detect"
+	check_set_exists tc_detect6 && pre_include "destroy set inet dscpclassify tc_detect6"
+	check_set_exists tc_orig_bulk && pre_include "destroy set inet dscpclassify tc_orig_bulk"
+	check_set_exists tc_orig_bulk6 && pre_include "destroy set inet dscpclassify tc_orig_bulk6"
+	check_set_exists tc_reply_bulk && pre_include "destroy set inet dscpclassify tc_reply_bulk"
+	check_set_exists tc_reply_bulk6 && pre_include "destroy set inet dscpclassify tc_reply_bulk6"
+	check_set_exists ts_detect && pre_include "destroy set inet dscpclassify ts_detect"
+	check_set_exists ts_detect6 && pre_include "destroy set inet dscpclassify ts_detect6"
 }
 
 create_pre_include() {
@@ -778,8 +794,8 @@ create_pre_include() {
 	pre_include "define lan = { $(format_list "$lan" ", " "\"") }"
 	pre_include "define wan = { $(format_list "$wan" ", " "\"") }"
 
-	[ "$action" = "reload" ] && create_flush_actions 
 	pre_include "add table inet dscpclassify"
+	[ "$action" = "reload" ] && create_flush_actions 
 
 	pre_include "include \"${VERDICTS}\""
 	pre_include "include \"${MAPS}\""
@@ -792,7 +808,7 @@ create_post_include() {
 	config_foreach create_user_set ipset # section name consistent with fw4
 	config_foreach_reverse create_user_rule rule
 
-	create_client_hints_jump || return 1
+	create_client_classify_jump || return 1
 	create_dynamic_classify_jump || return 1
 	create_threaded_client_rules || return 1
 	create_threaded_service_rules || return 1

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -4,17 +4,30 @@
 START=50
 USE_PROCD=1
 
+# Dynamic content
 DEBUG_FILE="/tmp/dscpclassify.debug"
 INCLUDES_PATH="/tmp/etc/dscpclassify.d"
 PRE_INCLUDE="${INCLUDES_PATH}/pre-include.nft"
 POST_INCLUDE="${INCLUDES_PATH}/post-include.nft"
 
+# Static content
 MAIN="/etc/dscpclassify.d/main.nft"
 VERDICTS="/etc/dscpclassify.d/verdicts.nft"
 MAPS="/etc/dscpclassify.d/maps.nft"
 
+# Configuration defaults
+CLASS_BULK=le
+CLASS_HIGH_THROUGHPUT=af13
+CLIENT_HINTS=1
+THREADED_CLIENT_MIN_BYTES=10000
+THREADED_CLIENT_MIN_CONNECTIONS=10
+THREADED_SERVICE_MIN_BYTES=1000000
+THREADED_SERVICE_MIN_CONNECTIONS=3
+WMM=0
+
 debug=1
 nft_result=""
+
 
 log() {
 	logger -t dscpclassify -p "daemon.$1" "$2"
@@ -90,7 +103,6 @@ fw_zone_dev() {
 	[ -n "$dev" ] || return 1
 
 	echo "$dev"
-	return 0
 }
 
 format_list() {
@@ -104,14 +116,13 @@ check_class() {
 	class="$(echo "$1" | tr 'A-Z' 'a-z')"
 
 	case "$class" in
-	le) [ "$2" = "var" ] && class="lephb" ;;
+	le) true ;;  # RFC-8622
 	be | df) class="cs0" ;;
 	cs0 | cs1 | af11 | af12 | af13 | cs2 | af21 | af22 | af23 | cs3 | af31 | af32 | af33 | cs4 | af41 | af42 | af43 | cs5 | va | ef | cs6 | cs7) true ;;
 	*) return 1 ;;
 	esac
 
 	echo "$class"
-	return 0
 }
 
 check_duration() {
@@ -187,13 +198,12 @@ check_set_exists() {
 }
 
 check_set_against_existing() {
-	local name type comment size flags timeout
+	local name="$1" type="$2" comment="$3" size="$4" flags="$5" timeout="$6"
 	local existing_set existing_type
 
-	name="$1"
 	existing_set=$(nft -t -j list set inet dscpclassify "$name" 2>/dev/null) || return 2
 
-	type="$(echo "$2" | sed 's/ \+\. \+/ /g')"
+	type="$(echo "$type" | sed 's/ \+\. \+/ /g')"
 	existing_type="$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.type")"
 	if [ -n "$existing_type" ]; then
 		[ "$existing_type" = "$type" ] || return 1
@@ -202,24 +212,21 @@ check_set_against_existing() {
 		[ "$existing_type" = "$type" ] || return 1
 	fi
 
-	comment="$3"
 	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.comment")" = "$comment" ] || return 1
 
-	size="$4"
 	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.size")" = "$size" ] || return 1
 
-	flags="$(echo "$5" | sed 's/, \+/ /g')"
+	flags="$(echo "$flags" | sed 's/, \+/ /g')"
 	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.flags[*]" | tr '\n' ' ' | sed 's/ *$//')" = "$flags" ] || return 1
 
-	timeout="$(convert_duration_to_seconds "$6")"
+	timeout="$(convert_duration_to_seconds "$timeout")"
 	[ "$(jsonfilter -s "$existing_set" -e "@.nftables[*].set.timeout")" = "$timeout" ] || return 1
 
 	return 0
 }
 
 check_uint() {
-	[ "$1" -ge 0 ] 2>/dev/null && return 0
-	return 1
+	[ "$1" -ge 0 ] 2>/dev/null
 }
 
 parse_rule_ports() {
@@ -539,18 +546,17 @@ rule_device() {
 }
 
 rule_verdict() {
-	local class
+	local class="$1"
 
-	[ -n "$1" ] || {
+	[ -n "$class" ] || {
 		log warning "Rule is missing the DSCP class option"
 		return 1
 	}
-	class="$(check_class "$1")" || {
+	class="$(check_class "$class")" || {
 		log warning "Rule contains an invalid DSCP class"
 		return 1
 	}
-
-	verdict="goto ct_set_$class"
+	verdict="goto ct_set_${class}"
 }
 
 create_user_rule() {
@@ -601,7 +607,7 @@ create_user_rule() {
 create_client_hints_rule() {
 	local client_hints
 
-	config_get_bool client_hints global client_hints 1
+	config_get_bool client_hints global client_hints $CLIENT_HINTS
 	[ "$client_hints" = 1 ] || return 0
 
 	post_include "insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != \$wan ip6 dscp vmap @dscp_ct"
@@ -611,17 +617,17 @@ create_client_hints_rule() {
 create_threaded_client_rule() {
 	local class_bulk threaded_client_min_bytes threaded_client_min_connections
 
-	config_get threaded_client_min_connections global threaded_client_min_connections 10
+	config_get threaded_client_min_connections global threaded_client_min_connections $THREADED_CLIENT_MIN_CONNECTIONS
 	if ! check_uint "$threaded_client_min_connections" || [ "$threaded_client_min_connections" -lt 2 ]; then
 		log err "Global option threaded_client_min_connections contains an invalid value"
 		return 1
 	fi
-	config_get threaded_client_min_bytes global threaded_client_min_bytes 10000
+	config_get threaded_client_min_bytes global threaded_client_min_bytes $THREADED_CLIENT_MIN_BYTES
 	if ! check_uint "$threaded_client_min_bytes" || [ "$threaded_client_min_bytes" = 0 ]; then
 		log err "Global option threaded_client_min_bytes contains an invalid value"
 		return 1
 	fi
-	config_get class_bulk global class_bulk le
+	config_get class_bulk global class_bulk $CLASS_BULK
 	class_bulk="$(check_class "$class_bulk")" || {
 		log err "Global option class_bulk contains an invalid DSCP class"
 		return 1
@@ -633,30 +639,30 @@ create_threaded_client_rule() {
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
 	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
-	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 
 	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
-	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_$class_bulk"
+	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } goto ct_set_${class_bulk}"
 }
 
 create_threaded_service_rule() {
 	local class_high_throughput threaded_service_min_bytes threaded_service_min_connections
 
-	config_get threaded_service_min_connections global threaded_service_min_connections 3
+	config_get threaded_service_min_connections global threaded_service_min_connections $THREADED_SERVICE_MIN_CONNECTIONS
 	if ! check_uint "$threaded_service_min_connections" || [ "$threaded_service_min_connections" -lt 2 ]; then
 		log err "Global option threaded_service_min_connections contains an invalid value"
 		return 1
 	fi
-	config_get threaded_service_min_bytes global threaded_service_min_bytes 1000000
+	config_get threaded_service_min_bytes global threaded_service_min_bytes $THREADED_SERVICE_MIN_BYTES
 	check_uint "$threaded_service_min_bytes" || {
 		log err "Global option threaded_service_min_bytes contains an invalid value"
 		return 1
 	}
-	config_get class_high_throughput global class_high_throughput af13
+	config_get class_high_throughput global class_high_throughput $CLASS_HIGH_THROUGHPUT
 	class_high_throughput="$(check_class "$class_high_throughput")" || {
 		log err "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
@@ -670,20 +676,20 @@ create_threaded_service_rule() {
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service goto ct_set_$class_high_throughput"
+	post_include "add rule inet dscpclassify threaded_service goto ct_set_${class_high_throughput}"
 
 	post_include "add rule inet dscpclassify threaded_service_reply ct reply bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
-	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_$class_high_throughput"
+	post_include "add rule inet dscpclassify threaded_service_reply goto ct_set_${class_high_throughput}"
 }
 
 create_dscp_mark_rule() {
 	local wmm
 
-	config_get_bool wmm global wmm 0
+	config_get_bool wmm global wmm $WMM
+	
 	[ "$wmm" = 1 ] && post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark & \$ct_dscp vmap @ct_wmm"
-
 	post_include "add rule inet dscpclassify postrouting ct mark & \$ct_dscp vmap @ct_dscp"
 }
 
@@ -801,6 +807,7 @@ start_service() {
 		return 1
 	}
 	cleanup_setup
+	return 0
 }
 
 reload_service() {
@@ -814,4 +821,5 @@ reload_service() {
 stop_service() {
 	cleanup_service
 	log notice "Service stopped"
+	return 0
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -630,7 +630,12 @@ create_dynamic_classify_jump() {
 	post_include "add rule inet dscpclassify postrouting ct mark & (\$ct_dynamic | \$ct_dscp) == \$ct_dynamic jump dynamic_classify"
 }
 
-create_threaded_client_rule() {
+destroy_threaded_client_rules() {
+	post_include "destroy chain inet dscpclassify threaded_client"
+	post_include "destroy chain inet dscpclassify threaded_client_reply"
+}
+
+create_threaded_client_rules() {
 	local class_bulk threaded_client_min_bytes threaded_client_min_connections
 
 	config_get threaded_client_min_connections global threaded_client_min_connections $THREADED_CLIENT_MIN_CONNECTIONS
@@ -648,25 +653,51 @@ create_threaded_client_rule() {
 		log err "Global option class_bulk contains an invalid DSCP class"
 		return 1
 	}
-	[ "$class_bulk" = "le" ] && class_bulk=lephb
 
+	# Destroy up old meter sets
+	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
+	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
+	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
+	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
+
+	case "$class_bulk" in
+	le) class_bulk=lephb ;;  # RFC-8622
+	cs0) destroy_threaded_client_rules; return 0 ;; # Skip rule creation
+	esac
+
+	# Create sets for matching threaded clients
+	check_set_exists threaded_clients || post_include "add set inet dscpclassify threaded_clients { type ipv4_addr . inet_service . inet_proto; flags timeout; }"
+	check_set_exists threaded_clients6 || post_include "add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }"
+
+	# Create threaded client detection rules
 	check_set_exists tc_detect && post_include "destroy set inet dscpclassify tc_detect"
 	check_set_exists tc_detect6 && post_include "destroy set inet dscpclassify tc_detect6"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect { ip daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients { ip daddr . th dport . meta l4proto timeout 30s }"
 	post_include "add rule inet dscpclassify established_connection meter tc_detect6 { ip6 daddr . th dport . meta l4proto timeout 5s limit rate over $((threaded_client_min_connections - 1))/minute } add @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 30s }"
 
-	check_set_exists tc_orig_bulk && post_include "destroy set inet dscpclassify tc_orig_bulk"
-	check_set_exists tc_orig_bulk6 && post_include "destroy set inet dscpclassify tc_orig_bulk6"
+	# Create threaded client classification rule chains
+	post_include "add chain inet dscpclassify threaded_client"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk { ip saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip saddr . th sport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
 	post_include "add rule inet dscpclassify threaded_client meter tc_orig_bulk6 { ip6 saddr . th sport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 saddr . th sport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
 
-	check_set_exists tc_reply_bulk && post_include "destroy set inet dscpclassify tc_reply_bulk"
-	check_set_exists tc_reply_bulk6 && post_include "destroy set inet dscpclassify tc_reply_bulk6"
+	post_include "add chain inet dscpclassify threaded_client_reply"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk { ip daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients { ip daddr . th dport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
 	post_include "add rule inet dscpclassify threaded_client_reply meter tc_reply_bulk6 { ip6 daddr . th dport . meta l4proto timeout 5m limit rate over $((threaded_client_min_bytes - 1)) bytes/hour } update @threaded_clients6 { ip6 daddr . th dport . meta l4proto timeout 5m } ct mark set ct mark | \$${class_bulk} return"
+
+	# Create jumps from dynamic_classify chain
+	post_include "add rule inet dscpclassify dynamic_classify ip saddr . th sport . meta l4proto @threaded_clients goto threaded_client"
+	post_include "add rule inet dscpclassify dynamic_classify ip6 saddr . th sport . meta l4proto @threaded_clients6 goto threaded_client"
+
+	post_include "add rule inet dscpclassify dynamic_classify_reply ip daddr . th dport . meta l4proto @threaded_clients goto threaded_client_reply"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ip6 daddr . th dport . meta l4proto @threaded_clients6 goto threaded_client_reply"
 }
 
-create_threaded_service_rule() {
+destroy_threaded_service_rules() {
+	post_include "destroy chain inet dscpclassify threaded_service"
+	post_include "destroy chain inet dscpclassify threaded_service_reply"
+}
+
+create_threaded_service_rules() {
 	local class_high_throughput threaded_service_min_bytes threaded_service_min_connections
 
 	config_get threaded_service_min_connections global threaded_service_min_connections $THREADED_SERVICE_MIN_CONNECTIONS
@@ -684,13 +715,25 @@ create_threaded_service_rule() {
 		log err "Global option class_high_throughput contains an invalid DSCP class"
 		return 1
 	}
-	[ "$class_high_throughput" = "le" ] && class_high_throughput=lephb
 
+	# Destroy up old meter sets
 	check_set_exists ts_detect && post_include "destroy set inet dscpclassify ts_detect"
 	check_set_exists ts_detect6 && post_include "destroy set inet dscpclassify ts_detect6"
+
+	case "$class_bulk" in
+	le) class_bulk=lephb ;;  # RFC-8622
+	cs0) destroy_threaded_service_rules; return 0 ;; # Skip rule creation
+	esac
+
+	# Create sets for matching threaded services
+	check_set_exists threaded_services || post_include "add set inet dscpclassify threaded_services { type ipv4_addr . ipv4_addr . inet_service . inet_proto; flags timeout; }"
+	check_set_exists threaded_services6 || post_include "add set inet dscpclassify threaded_services6 { type ipv6_addr . ipv6_addr . inet_service . inet_proto; flags timeout; }"
+
+	# Create threaded service detection rules
 	post_include "add rule inet dscpclassify established_connection meter ts_detect { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 30s }"
 	post_include "add rule inet dscpclassify established_connection meter ts_detect6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5s limit rate over $((threaded_service_min_connections - 1))/minute } add @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 30s }"
 
+	# Create threaded service classification rule chains
 	post_include "add rule inet dscpclassify threaded_service ct original bytes < $threaded_service_min_bytes return"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services { ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service update @threaded_services6 { ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto timeout 5m }"
@@ -700,14 +743,23 @@ create_threaded_service_rule() {
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services { ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply update @threaded_services6 { ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto timeout 5m }"
 	post_include "add rule inet dscpclassify threaded_service_reply ct mark set ct mark | \$${class_high_throughput} return"
+
+	# Create jumps from dynamic_classify chain
+	post_include "add chain inet dscpclassify threaded_service"
+	post_include "add rule inet dscpclassify dynamic_classify ip saddr . ip daddr and 255.255.255.0 . th dport . meta l4proto @threaded_services goto threaded_service"
+	post_include "add rule inet dscpclassify dynamic_classify ip6 saddr . ip6 daddr and ffff:ffff:ffff:: . th dport . meta l4proto @threaded_services6 goto threaded_service"
+
+	post_include "add chain inet dscpclassify threaded_service_reply"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ip daddr . ip saddr and 255.255.255.0 . th sport . meta l4proto @threaded_services goto threaded_service_reply"
+	post_include "add rule inet dscpclassify dynamic_classify_reply ip6 daddr . ip6 saddr and ffff:ffff:ffff:: . th sport . meta l4proto @threaded_services6 goto threaded_service_reply"
 }
 
 create_dscp_mark_rule() {
 	local wmm
 
 	config_get_bool wmm global wmm $WMM
-
 	[ "$wmm" = 1 ] && post_include "add rule inet dscpclassify postrouting oifname \$lan ct mark & \$ct_dscp vmap @ct_wmm"
+	
 	post_include "add rule inet dscpclassify postrouting ct mark & \$ct_dscp vmap @ct_dscp"
 }
 
@@ -728,10 +780,6 @@ create_pre_include() {
 
 	[ "$action" = "reload" ] && create_flush_actions 
 	pre_include "add table inet dscpclassify"
-	check_set_exists threaded_clients || pre_include "add set inet dscpclassify threaded_clients { type ipv4_addr . inet_service . inet_proto; flags timeout; }"
-	check_set_exists threaded_clients6 || pre_include "add set inet dscpclassify threaded_clients6 { type ipv6_addr . inet_service . inet_proto; flags timeout; }"
-	check_set_exists threaded_services || pre_include "add set inet dscpclassify threaded_services { type ipv4_addr . ipv4_addr . inet_service . inet_proto; flags timeout; }"
-	check_set_exists threaded_services6 || pre_include "add set inet dscpclassify threaded_services6 { type ipv6_addr . ipv6_addr . inet_service . inet_proto; flags timeout; }"
 
 	pre_include "include \"${VERDICTS}\""
 	pre_include "include \"${MAPS}\""
@@ -746,8 +794,8 @@ create_post_include() {
 
 	create_client_hints_jump || return 1
 	create_dynamic_classify_jump || return 1
-	create_threaded_client_rule || return 1
-	create_threaded_service_rule || return 1
+	create_threaded_client_rules || return 1
+	create_threaded_service_rules || return 1
 
 	create_dscp_mark_rule || return 1
 }

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -615,8 +615,7 @@ create_client_hints_rule() {
 	config_get_bool client_hints global client_hints $CLIENT_HINTS
 	[ "$client_hints" = 1 ] || return 0
 
-	post_include "insert rule inet dscpclassify static_classify ip6 dscp != { cs0, cs6, cs7 } iifname != \$wan ip6 dscp vmap @dscp_ct"
-	post_include "insert rule inet dscpclassify static_classify ip dscp != { cs0, cs6, cs7 } iifname != \$wan ip dscp vmap @dscp_ct"
+	post_include "insert rule inet dscpclassify dynamic_classify ct direction original iifname != \$wan jump client_classify"
 }
 
 create_threaded_client_rule() {
@@ -727,12 +726,11 @@ create_pre_include() {
 create_post_include() {
 	rm -f "$POST_INCLUDE"
 
-	create_client_hints_rule || return 1
-
 	config_foreach create_user_set set   # depreciating in favour of 'ipset' section name for consistency with fw4
 	config_foreach create_user_set ipset # section name consistent with fw4
 	config_foreach_reverse create_user_rule rule
 
+	create_client_hints_rule || return 1
 	create_threaded_client_rule || return 1
 	create_threaded_service_rule || return 1
 


### PR DESCRIPTION
## Overview
- Client class hints are now evaluated continuously for dynamic connections (previously the service only checked the first packet).
  - Addresses https://github.com/jeverley/dscpclassify/issues/34
- The dynamic bit is now preserved when a dynamic class is applied (threaded client/services)
  - This can be useful to understand _why_ a connection has a certain class (i.e. checking the bits set in the conntrack mark).
- Users now have the ability to disable the threaded client/service dynamic connection classification modes.
  - New global config option `dynamic_classify` (bool)

## Addresses issues
- https://github.com/jeverley/dscpclassify/issues/34