### PR TITLE
Handle named sections in migrate_config -> rename_section_type

### DIFF
--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -113,7 +113,7 @@ check_minimum_kernel_release() {
 	current_release=$(uname -r)
 	current_major=$(echo "$current_release" | awk -F '.' '{print $1}')
 	current_minor=$(echo "$current_release" | awk -F '.' '{print $2}')
-	
+
 	if [ "$current_major" -gt "$minimum_major" ] || { [ "$current_major" = "$minimum_major" ] && [ "$current_minor" -ge "${minimum_minor:-0}" ]; }; then
 		return 0
 	fi 2>/dev/null
@@ -181,11 +181,11 @@ unique_list() {
 }
 
 nft_element_list() {
-	format_list "$1" ", " "" "{}" 
+	format_list "$1" ", " "" "{}"
 }
 
 nft_interface_list() {
-	format_list "$1" ", " "\"" "{}" 
+	format_list "$1" ", " "\"" "{}"
 }
 
 nft_flag_list() {
@@ -1203,7 +1203,7 @@ create_dscp_mark_rule() {
 
 	config_get_bool wmm_mark_lan "$service_config" wmm_mark_lan "$wmm_mark_lan"
 	[ "$wmm_mark_lan" = 1 ] && post_include "add rule inet $TABLE postrouting oifname \$lan ct mark & \$$NFT_VAR_CT_DSCP vmap @ct_wmm"
-	
+
 	post_include "add rule inet $TABLE postrouting ct mark & \$$NFT_VAR_CT_DSCP vmap @ct_dscp"
 }
 
@@ -1232,7 +1232,7 @@ create_pre_include() {
 	pre_include "define wan = $(nft_interface_list "$wan")"
 
 	pre_include "add table inet $TABLE"
-	[ "$action" = "reload" ] && create_flush_actions 
+	[ "$action" = "reload" ] && create_flush_actions
 
 	pre_include "include \"${VERDICTS}\""
 	pre_include "include \"${MAPS}\""

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -1300,6 +1300,17 @@ migrate_config() {
 		echo "$section_ids"
 	}
 
+	# Get all section names of a given type
+	get_section_names() {
+		local type="$1" name section_names
+		for section in $(uci show "$CONFIG" | grep "=${type}" | cut -d'=' -f1); do
+			name=$(uci get "$section.name") || continue
+			section_names="${section_names:+$section_names }$name"
+		done
+		[ -n "$section_names" ] || return 1
+		echo "$section_names"
+	}
+
 	# Get all options of a given section
 	get_section_options() {
 		local section="$1" options
@@ -1354,8 +1365,9 @@ migrate_config() {
 	# Rename a section type
 	rename_section_type() {
 		local from_type="$1" to_type="$2"
-		local section_ids options new_id values
+		local section_ids section_names options new_id values
 
+		# Handle type without named sections
 		section_ids="$(get_section_ids "$from_type")" || return 0
 		for id in $section_ids; do
 			options=$(get_section_options "$CONFIG.$id") || {
@@ -1373,6 +1385,27 @@ migrate_config() {
 				}
 			done
 			uci delete "$CONFIG.$id"
+			changed=1
+		done
+
+		# Handle type with named sections
+		section_names="$(get_section_names "$from_type")" || return 0
+		for name in $section_names; do
+			options=$(get_section_options "$CONFIG.${name}") || {
+				uci delete "$CONFIG.${name}"
+				changed=1
+				continue
+			}
+			new_id=$(uci add "$CONFIG" "$to_type")
+			for option in $options; do
+				values=$(get_option_values "$CONFIG.${name}.$option") || continue
+				set_option_values "$CONFIG.$new_id.$option" "$values" || {
+					log err "Failed to rename section '$name' from type '$from_type' to '$to_type'"
+					error=1
+					return 1
+				}
+			done
+			uci delete "$CONFIG.${name}"
 			changed=1
 		done
 		return 0

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -1291,11 +1291,8 @@ migrate_config() {
 
 	# Get all section IDs of a given type
 	get_section_ids() {
-		local type="$1" id section_ids
-		for section in $(uci show "$CONFIG" | grep "@${type}\[[0-9]*\]=" | cut -d'=' -f1); do
-			id=$(uci show "$section" | head -n1 | cut -d'=' -f1 | cut -d'.' -f2) || continue
-			section_ids="${section_ids:+$section_ids }$id"
-		done
+		local type="$1" section_ids
+		section_ids="$(uci -X show "$CONFIG" | grep "=${type}$" | cut -d'=' -f1 | cut -d'.' -f2)"
 		[ -n "$section_ids" ] || return 1
 		echo "$section_ids"
 	}
@@ -1385,27 +1382,6 @@ migrate_config() {
 				}
 			done
 			uci delete "$CONFIG.$id"
-			changed=1
-		done
-
-		# Handle type with named sections
-		section_names="$(get_section_names "$from_type")" || return 0
-		for name in $section_names; do
-			options=$(get_section_options "$CONFIG.${name}") || {
-				uci delete "$CONFIG.${name}"
-				changed=1
-				continue
-			}
-			new_id=$(uci add "$CONFIG" "$to_type")
-			for option in $options; do
-				values=$(get_option_values "$CONFIG.${name}.$option") || continue
-				set_option_values "$CONFIG.$new_id.$option" "$values" || {
-					log err "Failed to rename section '$name' from type '$from_type' to '$to_type'"
-					error=1
-					return 1
-				}
-			done
-			uci delete "$CONFIG.${name}"
 			changed=1
 		done
 		return 0

--- a/etc/init.d/dscpclassify
+++ b/etc/init.d/dscpclassify
@@ -1297,17 +1297,6 @@ migrate_config() {
 		echo "$section_ids"
 	}
 
-	# Get all section names of a given type
-	get_section_names() {
-		local type="$1" name section_names
-		for section in $(uci show "$CONFIG" | grep "=${type}" | cut -d'=' -f1); do
-			name=$(uci get "$section.name") || continue
-			section_names="${section_names:+$section_names }$name"
-		done
-		[ -n "$section_names" ] || return 1
-		echo "$section_names"
-	}
-
 	# Get all options of a given section
 	get_section_options() {
 		local section="$1" options
@@ -1362,9 +1351,8 @@ migrate_config() {
 	# Rename a section type
 	rename_section_type() {
 		local from_type="$1" to_type="$2"
-		local section_ids section_names options new_id values
+		local section_ids options new_id values
 
-		# Handle type without named sections
 		section_ids="$(get_section_ids "$from_type")" || return 0
 		for id in $section_ids; do
 			options=$(get_section_options "$CONFIG.$id") || {


### PR DESCRIPTION
**Description**
This PR improves the config migration logic in dscpclassify by properly
handling UCI sections that are named \(e.g., `config <type> <name>`\) in
addition to the existing support for anonymous/numeric section IDs.

**What changed**
Adds a helper to enumerate section names for a given UCI section type.
Extends the migration's "rename section type" path to migrate both:

- unnamed sections (existing behavior)
- named sections (new behavior)

Preserves all options/values and cleans up the old sections.

**Why**
Some deployments/configs use named UCI sections; without this, those
sections were skipped during type renames in migration, leaving configs
partially migrated.

**Testing**
Ran migration on configs containing both unnamed and named sections and
verified options/values were carried over and old sections removed cleanly.
